### PR TITLE
fix printing

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -285,5 +285,6 @@ function print_annotation(
     k::Int)
 
     printstyled(io, node.locs; bold=true, color=:white)
+    print(io, " ")
     print_annotation(io, child)
 end


### PR DESCRIPTION
Before:

```
julia> control(4, (1, 2), 3=>X)
nqubits: 4, datatype: Complex{Float64}
control(1, 2)
└─ (3,)X gate
```

After:

```julia
julia> control(4, (1, 2), 3=>X)
nqubits: 4, datatype: Complex{Float64}
control(1, 2)
└─ (3,) X gate
```