### PR TITLE
fix const gate generation

### DIFF
--- a/src/primitive/const_gate_tools.jl
+++ b/src/primitive/const_gate_tools.jl
@@ -123,7 +123,7 @@ function define_struct(__module__::Module, __source__::LineNumberNode, const_bin
     end
     # calculate new shape
     N = gensym(:N)
-    push!(ex.args, :(@eval $__module__ $N = BitBasis.log2i(size($(const_binding), 1))))
+    push!(ex.args, :(@eval $__module__ $N = $log2i(size($(const_binding), 1))))
 
     # we allow overwrite in order to support the following syntax
     # @const_gate X = BLABLA
@@ -131,7 +131,7 @@ function define_struct(__module__::Module, __source__::LineNumberNode, const_bin
     if isdefined(__module__, gt_name)
         msg = "$(string(gt_name)) is already defined, overwritten by new definition at $__source__"
         push!(ex.args, :(@warn $msg))
-        push!(ex.args, :(@eval $__module__ @assert $N == BitBasis.log2i(size(mat($name), 1)) "new constant does not have the same size with previous definitions"))
+        push!(ex.args, :(@eval $__module__ @assert $N == $log2i(size(mat($name), 1)) "new constant does not have the same size with previous definitions"))
     else
         push!(ex.args, :(@eval $__module__ Base.@__doc__ struct $gt_name{T} <: YaoBlocks.ConstGate.ConstantGate{$N, T} end))
     end


### PR DESCRIPTION
This fix the following issue:

```julia
@const_gate MyConstGate = rand(4, 4)
UndefVarError: BitBasis not defined

Stacktrace:
 [1] top-level scope at none:0
 [2] eval(::Module, ::Any) at /Users/roger/.julia/lib/julia/sys.dylib:?
 [3] top-level scope at /Users/roger/.julia/dev/YaoBlocks/src/primitive/const_gate_tools.jl:90
 [4] top-level scope at In[31]:1
```