### PR TITLE
loose type constraints to support symbolic computation

### DIFF
--- a/src/primitive/phase_gate.jl
+++ b/src/primitive/phase_gate.jl
@@ -36,7 +36,7 @@ mat(::Type{T}, gate::PhaseGate) where T = exp(T(im * gate.theta)) * IMatrix{2, T
 # parametric interface
 niparams(::Type{<:PhaseGate}) = 1
 getiparams(x::PhaseGate) = x.theta
-setiparams!(r::PhaseGate, param::Real) = (r.theta = param; r)
+setiparams!(r::PhaseGate, param) = (r.theta = param; r)
 
 YaoBase.isunitary(r::PhaseGate) = true
 Base.adjoint(blk::PhaseGate) = PhaseGate(-blk.theta)

--- a/src/primitive/phase_gate.jl
+++ b/src/primitive/phase_gate.jl
@@ -38,7 +38,8 @@ niparams(::Type{<:PhaseGate}) = 1
 getiparams(x::PhaseGate) = x.theta
 setiparams!(r::PhaseGate, param) = (r.theta = param; r)
 
-YaoBase.isunitary(r::PhaseGate) = true
+# fallback to matrix method if it is not real
+YaoBase.isunitary(r::PhaseGate{<:Real}) = true
 Base.adjoint(blk::PhaseGate) = PhaseGate(-blk.theta)
 Base.copy(block::PhaseGate{T}) where T = PhaseGate{T}(block.theta)
 Base.:(==)(lhs::PhaseGate, rhs::PhaseGate) = lhs.theta == rhs.theta

--- a/src/primitive/phase_gate.jl
+++ b/src/primitive/phase_gate.jl
@@ -40,6 +40,13 @@ setiparams!(r::PhaseGate, param) = (r.theta = param; r)
 
 # fallback to matrix method if it is not real
 YaoBase.isunitary(r::PhaseGate{<:Real}) = true
+
+function YaoBase.isunitary(r::PhaseGate)
+    isreal(r.theta) && return true
+    @warn "θ in phase(θ) is not real, got $(r.theta), fallback to matrix-based method"
+    return isunitary(mat(r))
+end
+
 Base.adjoint(blk::PhaseGate) = PhaseGate(-blk.theta)
 Base.copy(block::PhaseGate{T}) where T = PhaseGate{T}(block.theta)
 Base.:(==)(lhs::PhaseGate, rhs::PhaseGate) = lhs.theta == rhs.theta

--- a/src/primitive/phase_gate.jl
+++ b/src/primitive/phase_gate.jl
@@ -29,7 +29,7 @@ julia> phase(0.1)
 phase(0.1)
 ```
 """
-phase(θ::AbstractFloat) = PhaseGate(θ)
+phase(θ::Real) = PhaseGate(θ)
 
 mat(::Type{T}, gate::PhaseGate) where T = exp(T(im * gate.theta)) * IMatrix{2, T}()
 

--- a/src/primitive/phase_gate.jl
+++ b/src/primitive/phase_gate.jl
@@ -30,7 +30,6 @@ phase(0.1)
 ```
 """
 phase(θ::AbstractFloat) = PhaseGate(θ)
-phase(θ::Real) = phase(Float64(θ))
 
 mat(::Type{T}, gate::PhaseGate) where T = exp(T(im * gate.theta)) * IMatrix{2, T}()
 

--- a/src/primitive/phase_gate.jl
+++ b/src/primitive/phase_gate.jl
@@ -7,7 +7,7 @@ export PhaseGate, phase
 
 Global phase gate.
 """
-mutable struct PhaseGate{T <: Real} <: PrimitiveBlock{1}
+mutable struct PhaseGate{T} <: PrimitiveBlock{1}
     theta::T
 end
 

--- a/src/primitive/phase_gate.jl
+++ b/src/primitive/phase_gate.jl
@@ -36,7 +36,7 @@ mat(::Type{T}, gate::PhaseGate) where T = exp(T(im * gate.theta)) * IMatrix{2, T
 # parametric interface
 niparams(::Type{<:PhaseGate}) = 1
 getiparams(x::PhaseGate) = x.theta
-setiparams!(r::PhaseGate, param) = (r.theta = param; r)
+setiparams!(r::PhaseGate, param::Number) = (r.theta = param; r)
 
 # fallback to matrix method if it is not real
 YaoBase.isunitary(r::PhaseGate{<:Real}) = true

--- a/src/primitive/rotation_gate.jl
+++ b/src/primitive/rotation_gate.jl
@@ -103,7 +103,7 @@ end
 niparams(::Type{<:RotationGate}) = 1
 getiparams(x::RotationGate) = x.theta
 # no need to specify the type of param, Julia will try to do the conversion
-setiparams!(r::RotationGate, param) where {N, T} = (r.theta = param; r)
+setiparams!(r::RotationGate, param::Number) where {N, T} = (r.theta = param; r)
 
 # fallback to matrix methods if it is not real
 YaoBase.isunitary(r::RotationGate{N, <:Real}) where N = true

--- a/src/primitive/rotation_gate.jl
+++ b/src/primitive/rotation_gate.jl
@@ -13,7 +13,7 @@ RotationGate, with GT both hermitian and isreflexive.
 \\mathbf{I} cos(θ / 2) - im sin(θ / 2) * mat(U)
 ```
 """
-mutable struct RotationGate{N, T <: Real, GT <: AbstractBlock{N}} <: PrimitiveBlock{N}
+mutable struct RotationGate{N, T, GT <: AbstractBlock{N}} <: PrimitiveBlock{N}
     block::GT
     theta::T
     function RotationGate{N, T, GT}(block::GT, theta) where {N, T, GT <: AbstractBlock{N}}

--- a/src/primitive/rotation_gate.jl
+++ b/src/primitive/rotation_gate.jl
@@ -23,7 +23,7 @@ mutable struct RotationGate{N, T, GT <: AbstractBlock{N}} <: PrimitiveBlock{N}
     end
 end
 
-RotationGate(block::GT, theta::T) where {N, T <: Real, GT<:AbstractBlock{N}} = RotationGate{N, T, GT}(block, theta)
+RotationGate(block::GT, theta::T) where {N, T, GT<:AbstractBlock{N}} = RotationGate{N, T, GT}(block, theta)
 
 # bindings
 """

--- a/src/primitive/rotation_gate.jl
+++ b/src/primitive/rotation_gate.jl
@@ -102,7 +102,8 @@ end
 # parametric interface
 niparams(::Type{<:RotationGate}) = 1
 getiparams(x::RotationGate) = x.theta
-setiparams!(r::RotationGate, param::Real) = (r.theta = param; r)
+# no need to specify the type of param, Julia will try to do the conversion
+setiparams!(r::RotationGate, param) where {N, T} = (r.theta = param; r)
 
 YaoBase.isunitary(r::RotationGate) = true
 

--- a/src/primitive/rotation_gate.jl
+++ b/src/primitive/rotation_gate.jl
@@ -23,9 +23,7 @@ mutable struct RotationGate{N, T <: Real, GT <: AbstractBlock{N}} <: PrimitiveBl
     end
 end
 
-RotationGate(block::GT, theta::T) where {N, T <: AbstractFloat, GT<:AbstractBlock{N}} = RotationGate{N, T, GT}(block, theta)
-# convert to float if theta is not a floating point
-RotationGate(block::AbstractBlock, theta) = RotationGate(block, Float64(theta))
+RotationGate(block::GT, theta::T) where {N, T <: Real, GT<:AbstractBlock{N}} = RotationGate{N, T, GT}(block, theta)
 
 # bindings
 """

--- a/src/primitive/rotation_gate.jl
+++ b/src/primitive/rotation_gate.jl
@@ -108,6 +108,12 @@ setiparams!(r::RotationGate, param) where {N, T} = (r.theta = param; r)
 # fallback to matrix methods if it is not real
 YaoBase.isunitary(r::RotationGate{N, <:Real}) where N = true
 
+function YaoBase.isunitary(r::RotationGate)
+    isreal(r.theta) && return true
+    @warn "θ in RotationGate is not real, got θ=$(r.theta), fallback to matrix-based method"
+    return isunitary(mat(r))
+end
+
 Base.adjoint(blk::RotationGate) = RotationGate(blk.block, -blk.theta)
 Base.copy(R::RotationGate) = RotationGate(R.block, R.theta)
 Base.:(==)(lhs::RotationGate{TA, GTA}, rhs::RotationGate{TB, GTB}) where {TA, TB, GTA, GTB} = false

--- a/src/primitive/rotation_gate.jl
+++ b/src/primitive/rotation_gate.jl
@@ -105,7 +105,8 @@ getiparams(x::RotationGate) = x.theta
 # no need to specify the type of param, Julia will try to do the conversion
 setiparams!(r::RotationGate, param) where {N, T} = (r.theta = param; r)
 
-YaoBase.isunitary(r::RotationGate) = true
+# fallback to matrix methods if it is not real
+YaoBase.isunitary(r::RotationGate{N, <:Real}) where N = true
 
 Base.adjoint(blk::RotationGate) = RotationGate(blk.block, -blk.theta)
 Base.copy(R::RotationGate) = RotationGate(R.block, R.theta)

--- a/src/primitive/shift_gate.jl
+++ b/src/primitive/shift_gate.jl
@@ -46,4 +46,6 @@ setiparams!(r::ShiftGate, param) = (r.theta = param; r)
 Base.adjoint(blk::ShiftGate) = ShiftGate(-blk.theta)
 Base.copy(block::ShiftGate{T}) where T = ShiftGate{T}(block.theta)
 Base.:(==)(lhs::ShiftGate, rhs::ShiftGate) = lhs.theta == rhs.theta
-YaoBase.isunitary(r::ShiftGate) = true
+
+# fallback to matrix method if it is not real
+YaoBase.isunitary(r::ShiftGate{<:Real}) = true

--- a/src/primitive/shift_gate.jl
+++ b/src/primitive/shift_gate.jl
@@ -16,7 +16,7 @@ Phase shift gate.
 \\end{pmatrix}
 ```
 """
-mutable struct ShiftGate{T <: Real} <: PrimitiveBlock{1}
+mutable struct ShiftGate{T} <: PrimitiveBlock{1}
     theta::T
 end
 
@@ -33,7 +33,7 @@ shift(0.1)
 ```
 """
 shift(θ::Real) = ShiftGate(θ)
-mat(::Type{T}, gate::ShiftGate) where {T <: Complex} = Diagonal(T[1.0, exp(im * gate.theta)])
+mat(::Type{T}, gate::ShiftGate) where T = Diagonal(T[1.0, exp(im * gate.theta)])
 
 cache_key(gate::ShiftGate) = gate.theta
 

--- a/src/primitive/shift_gate.jl
+++ b/src/primitive/shift_gate.jl
@@ -49,3 +49,9 @@ Base.:(==)(lhs::ShiftGate, rhs::ShiftGate) = lhs.theta == rhs.theta
 
 # fallback to matrix method if it is not real
 YaoBase.isunitary(r::ShiftGate{<:Real}) = true
+
+function YaoBase.isunitary(r::ShiftGate)
+    isreal(r.theta) && return true
+    @warn "θ in ShiftGate is not real, got θ=$(r.theta), fallback to matrix-based method"
+    return isunitary(mat(r))
+end

--- a/src/primitive/shift_gate.jl
+++ b/src/primitive/shift_gate.jl
@@ -40,7 +40,7 @@ cache_key(gate::ShiftGate) = gate.theta
 # parametric interface
 niparams(::Type{<:ShiftGate}) = 1
 getiparams(x::ShiftGate) = x.theta
-setiparams!(r::ShiftGate, param) = (r.theta = param; r)
+setiparams!(r::ShiftGate, param::Number) = (r.theta = param; r)
 
 
 Base.adjoint(blk::ShiftGate) = ShiftGate(-blk.theta)

--- a/src/primitive/shift_gate.jl
+++ b/src/primitive/shift_gate.jl
@@ -32,8 +32,7 @@ julia> shift(0.1)
 shift(0.1)
 ```
 """
-shift(θ::AbstractFloat) = ShiftGate(θ)
-shift(θ::Real) = shift(Float64(θ))
+shift(θ::Real) = ShiftGate(θ)
 mat(::Type{T}, gate::ShiftGate) where {T <: Complex} = Diagonal(T[1.0, exp(im * gate.theta)])
 
 cache_key(gate::ShiftGate) = gate.theta

--- a/src/primitive/shift_gate.jl
+++ b/src/primitive/shift_gate.jl
@@ -40,7 +40,7 @@ cache_key(gate::ShiftGate) = gate.theta
 # parametric interface
 niparams(::Type{<:ShiftGate}) = 1
 getiparams(x::ShiftGate) = x.theta
-setiparams!(r::ShiftGate, param::Real) = (r.theta = param; r)
+setiparams!(r::ShiftGate, param) = (r.theta = param; r)
 
 
 Base.adjoint(blk::ShiftGate) = ShiftGate(-blk.theta)

--- a/src/primitive/shift_gate.jl
+++ b/src/primitive/shift_gate.jl
@@ -32,7 +32,7 @@ julia> shift(0.1)
 shift(0.1)
 ```
 """
-shift(θ::Real) = ShiftGate(θ)
+shift(θ) = ShiftGate(θ)
 mat(::Type{T}, gate::ShiftGate) where T = Diagonal(T[1.0, exp(im * gate.theta)])
 
 cache_key(gate::ShiftGate) = gate.theta

--- a/test/primitive/phase_gate.jl
+++ b/test/primitive/phase_gate.jl
@@ -5,7 +5,6 @@ using Test, YaoBlocks, YaoArrayRegister, LuxurySparse
     @test PhaseGate(0.1) isa PrimitiveBlock{1}
     @test_throws TypeError PhaseGate{Complex{T}} # will not accept non-real type
     @test phase(T(0.1)) isa PrimitiveBlock{1}
-    @test phase(1) isa PhaseGate{Float64} # default we convert to float64
 end
 
 @testset "test copy" begin

--- a/test/primitive/phase_gate.jl
+++ b/test/primitive/phase_gate.jl
@@ -44,4 +44,11 @@ end
     @test isreflexive(g) == false
     @test isunitary(g) == true
     @test ishermitian(g) == false
+
+
+    g = PhaseGate{ComplexF64}(1.0+0im)
+    @test @test_nowarn isunitary(g) == true
+
+    g = PhaseGate{ComplexF64}(1.0+1im)
+    @test @test_logs (:warn, "θ in phase(θ) is not real, got $(g.theta), fallback to matrix-based method") isunitary(g) == false
 end

--- a/test/primitive/phase_gate.jl
+++ b/test/primitive/phase_gate.jl
@@ -3,7 +3,6 @@ using Test, YaoBlocks, YaoArrayRegister, LuxurySparse
 
 @testset "test constructor" for T in [Float16, Float32, Float64]
     @test PhaseGate(0.1) isa PrimitiveBlock{1}
-    @test_throws TypeError PhaseGate{Complex{T}} # will not accept non-real type
     @test phase(T(0.1)) isa PrimitiveBlock{1}
 end
 

--- a/test/primitive/rotation_gate.jl
+++ b/test/primitive/rotation_gate.jl
@@ -3,7 +3,6 @@ using Test, YaoBlocks, YaoArrayRegister
 @testset "test constructor" for T in [Float16, Float32, Float64]
     # NOTE: type should follow the axis
     @test RotationGate(X, 0.1) isa PrimitiveBlock{1}
-    @test_throws TypeError RotationGate{1, Complex{T}, XGate} # will not accept non-real type
 
     @test Rx(T(0.1)) isa RotationGate{1, T, XGate}
     @test Ry(T(0.1)) isa RotationGate{1, T, YGate}

--- a/test/primitive/rotation_gate.jl
+++ b/test/primitive/rotation_gate.jl
@@ -46,3 +46,14 @@ end
     g = Rx(0.1) # creates a new one
     @test copy(g) !== g
 end
+
+@testset "isunitary" begin
+    g = Rx(0.1 + 0im)
+    @test @test_nowarn isunitary(g) == true
+
+    g = Rx(0.1 + 1im)
+    @test @test_logs (
+        :warn,
+        "θ in RotationGate is not real, got θ=$(g.theta), fallback to matrix-based method"
+        ) isunitary(g) == false
+end

--- a/test/primitive/shift_gate.jl
+++ b/test/primitive/shift_gate.jl
@@ -35,6 +35,12 @@ end
     @test isreflexive(g) == false
     @test isunitary(g) == true
     @test ishermitian(g) == false
+
+    g = ShiftGate{ComplexF64}(0.1 + 0im)
+    @test @test_nowarn isunitary(g) == true
+
+    g = ShiftGate{ComplexF64}(0.1 + 1im)
+    @test @test_logs (:warn, "θ in ShiftGate is not real, got θ=0.1 + 1.0im, fallback to matrix-based method") isunitary(g) == false
 end
 
 @testset "test parameters" begin

--- a/test/primitive/shift_gate.jl
+++ b/test/primitive/shift_gate.jl
@@ -2,7 +2,6 @@ using Test, YaoBlocks, YaoArrayRegister
 
 @testset "test constructor" for T in [Float16, Float32, Float64]
     @test ShiftGate(T(0.1)) isa ShiftGate{T}
-    @test_throws TypeError ShiftGate{Complex{T}} # will not accept non-real type
     @test shift(T(0.1)) isa ShiftGate{T}
     @test adjoint(shift(0.1)) == shift(-0.1)
 end


### PR DESCRIPTION
don't merge. I'll wrap up things later in this semester.

since we moved precision type out of the IR in #37 , there's no need to constraint parameters to be `AbstractFloat` anymore. And removing this constrain will make some symbolic computation "just work".

But I need to wrap up some patches later (maybe in a new package), so don't merge for now. Some of the calculation will just work at the moment, e.g

![image](https://user-images.githubusercontent.com/8445510/64662389-45fba700-d416-11e9-94c0-d9995661ccb2.png)
