### PR TITLE
automatic differentiation

### DIFF
--- a/src/YaoBlocks.jl
+++ b/src/YaoBlocks.jl
@@ -16,6 +16,8 @@ include("algebra.jl")
 include("blocktools.jl")
 include("layout.jl")
 
+include("autodiff/autodiff.jl")
+
 include("deprecations.jl")
 
 end # YaoBlocks

--- a/src/YaoBlocks.jl
+++ b/src/YaoBlocks.jl
@@ -17,6 +17,7 @@ include("blocktools.jl")
 include("layout.jl")
 
 include("autodiff/autodiff.jl")
+export AD
 
 include("deprecations.jl")
 

--- a/src/abstract_block.jl
+++ b/src/abstract_block.jl
@@ -175,7 +175,15 @@ Returns all the parameters contained in block tree with given root `block`.
 Append all the parameters contained in block tree with given root `block` to
 `out`.
 """
-@interface parameters!(out, x::AbstractBlock) = prewalk(blk->append!(out, getiparams(blk)), x)
+@interface function parameters!(out, x::AbstractBlock)
+    append!(out, getiparams(x))
+    for blk in subblocks(x)
+        parameters!(out, blk)
+    end
+    return out
+end
+
+# = prewalk(blk->append!(out, getiparams(blk)), x)
 
 """
     nparameters(block) -> Int
@@ -260,7 +268,7 @@ Dispatch parameters in collection to block tree `x`.
 @interface function dispatch!(f::Union{Function, Nothing}, x::AbstractBlock, it)
     dp = Dispatcher(it)
     res = dispatch!(f, x, dp)
-    @assert (it isa Symbol || length(it) == dp.loc) "expect $(nparameters(x)) parameters, got $(length(it))"
+    @assert (it isa Symbol || length(it) == dp.loc) "expect $(dp.loc) parameters, got $(length(it))"
     return res
 end
 

--- a/src/autodiff/NoParams.jl
+++ b/src/autodiff/NoParams.jl
@@ -1,0 +1,13 @@
+export NoParams
+
+struct NoParams{N,BT<:AbstractBlock{N}}<:TagBlock{BT,N}
+    content::BT
+end
+
+YaoBlocks.parameters!(out, x::NoParams) = out
+YaoBlocks.nparameters(x::NoParams) = 0
+YaoBlocks.niparams(x::NoParams) = 0
+YaoBlocks.mat(::Type{T}, x::NoParams) where T = mat(T, content(x))
+YaoBlocks.PropertyTrait(x::NoParams) = PreserveAll()
+YaoBlocks.dispatch!(f::Union{Function, Nothing}, x::NoParams, it::YaoBlocks.Dispatcher) = return x
+Base.adjoint(x::NoParams) = NoParams(adjoint(content(x)))

--- a/src/autodiff/adjroutines.jl
+++ b/src/autodiff/adjroutines.jl
@@ -1,0 +1,115 @@
+@inline function adjunij!(mat::AbstractMatrix, locs, U::Matrix)
+    for j = 1:size(U, 2)
+        for i = 1:size(U, 2)
+            U[i,j] += mat[locs[i],locs[j]]
+        end
+    end
+    return U
+end
+
+@inline function adjunij!(mat::AbstractMatrix, locs, U::SparseMatrixCSC)
+    for j = 1:size(U, 2)
+        S = U.colptr[j]
+        E = U.colptr[j+1]-1
+        for ii = S:E
+            U.nzval[ii] += mat[locs[U.rowval[ii]],locs[j]]
+        end
+    end
+    return U
+end
+
+@inline function adjunij!(mat::SDDiagonal, locs, U::Diagonal)
+    @inbounds U.diag .+= mat.diag[locs]
+    return U
+end
+
+@inline function adjunij!(mat::AbstractMatrix, locs, U::Diagonal)
+    for i=1:size(U,1)
+        li = locs[i]
+        U.diag[i] += mat[li, li]
+    end
+    return U
+end
+
+@inline function adjunij!(mat::SDPermMatrix, locs, U::PermMatrix)
+    @inbounds U.vals .+= mat.vals[locs]
+    return U
+end
+
+@inline function adjunij!(mat::AbstractMatrix, locs, U::PermMatrix)
+    for i=1:size(U, 1)
+        U.vals[i] += mat[locs[i], locs[U.perm[i]]]
+    end
+    return U
+end
+
+function adjcunmat(adjy::AbstractMatrix, nbit::Int, cbits::NTuple{C, Int}, cvals::NTuple{C, Int}, U0::AbstractMatrix{T}, locs::NTuple{M, Int}) where {C, M, T}
+    U, ic, locs_raw = YaoBlocks.reorder_unitary(nbit, cbits, cvals, U0, locs)
+    adjU = _render_adjU(U)
+
+    controldo(ic) do i
+        adjunij!(adjy, locs_raw+i, adjU)
+    end
+
+    adjU = all(diff([locs...]).>0) ? adjU : YaoBase.reorder(adjU, collect(locs)|>sortperm|>sortperm)
+    adjU
+end
+
+@inline function adju1ij!(csc::SparseMatrixCSC{T}, i::Int,j::Int, adjU::Matrix) where T
+    @inbounds begin
+        adjU[1,1] += csc.nzval[2*i-1]
+        adjU[1,2] += csc.nzval[2*i]
+        adjU[2,1] += csc.nzval[2*j-1]
+        adjU[2,2] += csc.nzval[2*j]
+    end
+    adjU
+end
+
+function adju1mat(adjy, nbit::Int, U1::SDMatrix, ibit::Int)
+    mask = bmask(ibit)
+    step = 1<<(ibit-1)
+    step_2 = 1<<ibit
+
+    adjy = projection(YaoBlocks._initialize_output(nbit, 0, U1), adjy)
+    adjU = _render_adjU(U1)
+
+    for j = 0:step_2:1<<nbit-step
+        @inbounds @simd for i = j+1:j+step
+            adju1ij!(adjy, i, i+step, adjU)
+        end
+    end
+    adjU
+end
+
+_render_adjU(U0::AbstractMatrix{T}) where T = zeros(T, size(U0)...)
+_render_adjU(U0::SDSparseMatrixCSC{T}) where T = SparseMatrixCSC(size(U0)..., dynamicize(U0.colptr), dynamicize(U0.rowval), zeros(T, U0.nzval|>length))
+_render_adjU(U0::SDDiagonal{T}) where T = Diagonal(zeros(T, size(U0, 1)))
+_render_adjU(U0::SDPermMatrix{T}) where T = PermMatrix(U0.perm, zeros(T, length(U0.vals)))
+
+# DEPRECATED
+#=
+@inline function adjsetcol!(csc::SparseMatrixCSC, icol::Int, rowval::AbstractVector, nzval::SubArray)
+    begin
+        S = csc.colptr[icol]
+        E = csc.colptr[icol+1]-1
+        nzval .+= view(csc.nzval, S:E)
+    end
+    csc
+end
+
+@inline function adjunij!(mat::SparseMatrixCSC, locs, U::Matrix)
+    for j = 1:size(U, 2)
+        adjsetcol!(mat, locs[j], locs, view(U,:,j))
+    end
+    return U
+end
+
+@inline function adjunij!(mat::SparseMatrixCSC, locs, U::SparseMatrixCSC)
+    for j = 1:size(U, 2)
+        S = U.colptr[j]
+        E = U.colptr[j+1]-1
+        @inbounds adjsetcol!(mat, locs[j], locs, view(U.nzval,S:E))
+    end
+    return U
+end
+=#

--- a/src/autodiff/adjroutines.jl
+++ b/src/autodiff/adjroutines.jl
@@ -1,18 +1,18 @@
 @inline function adjunij!(mat::AbstractMatrix, locs, U::Matrix)
     for j = 1:size(U, 2)
         for i = 1:size(U, 2)
-            U[i,j] += mat[locs[i],locs[j]]
+            @inbounds U[i,j] += mat[locs[i],locs[j]]
         end
     end
     return U
 end
 
 @inline function adjunij!(mat::AbstractMatrix, locs, U::SparseMatrixCSC)
-    for j = 1:size(U, 2)
+    @inbounds for j = 1:size(U, 2)
         S = U.colptr[j]
         E = U.colptr[j+1]-1
         for ii = S:E
-            U.nzval[ii] += mat[locs[U.rowval[ii]],locs[j]]
+            @inbounds U.nzval[ii] += mat[locs[U.rowval[ii]],locs[j]]
         end
     end
     return U
@@ -24,7 +24,7 @@ end
 end
 
 @inline function adjunij!(mat::AbstractMatrix, locs, U::Diagonal)
-    for i=1:size(U,1)
+    @inbounds for i=1:size(U,1)
         li = locs[i]
         U.diag[i] += mat[li, li]
     end
@@ -38,7 +38,7 @@ end
 
 @inline function adjunij!(mat::AbstractMatrix, locs, U::PermMatrix)
     for i=1:size(U, 1)
-        U.vals[i] += mat[locs[i], locs[U.perm[i]]]
+        @inbounds U.vals[i] += mat[locs[i], locs[U.perm[i]]]
     end
     return U
 end

--- a/src/autodiff/apply_back.jl
+++ b/src/autodiff/apply_back.jl
@@ -1,0 +1,173 @@
+export apply_back!, apply_back
+
+const Rotor{N, T} = Union{RotationGate{N, T}, PutBlock{N, <:Any, <:RotationGate{<:Any, T}}}
+
+"""
+    generator(rot::Rotor) -> AbstractBlock
+
+Return the generator of rotation block.
+"""
+generator(rot::RotationGate) = rot.block
+generator(rot::PutBlock{N, C, GT}) where {N, C, GT<:RotationGate} = PutBlock{N}(generator(rot|>content), rot |> occupied_locs)
+
+"""
+    apply_back!((ψ, ∂L/∂ψ*), circuit::AbstractBlock, collector) -> AbstractRegister
+
+back propagate and calculate the gradient ∂L/∂θ = 2*Re(∂L/∂ψ*⋅∂ψ*/∂θ), given ∂L/∂ψ*.
+`ψ` is the output register, ∂L/∂ψ* should also be register type.
+
+Note: gradients are stored in `Diff` blocks, it can be access by either `diffblock.grad` or `gradient(circuit)`.
+Note2: now `apply_back!` returns the inversed gradient!
+"""
+function apply_back!(st, block::AbstractBlock, collector) #,AbstractContainer{<:PrimitiveBlock}
+    out, outδ = st
+    if nparameters(block) == 0
+        adjblock = block'
+        in = apply!(out, adjblock)
+        inδ = apply!(outδ, adjblock)
+        return (in, inδ)
+    else
+        throw(MethodError(apply_back, (st, block, collector)))
+    end
+end
+
+function apply_back!(st, block::Concentrator{N}, collector) where N
+    out, outδ = st
+    focus!(out, block.locs)
+    focus!(outδ, block.locs)
+    apply_back!((out, outδ), content(block), collector)
+    relax!(out, block.locs; to_nactive=N)
+    relax!(outδ, block.locs; to_nactive=N)
+    return (out, outδ)
+end
+
+function apply_back!(st, block::Rotor{N}, collector) where N
+    out, outδ = st
+    adjblock = block'
+    backward_params!((out, outδ), block, collector)
+    in = apply!(out, adjblock)
+    inδ = apply!(outδ, adjblock)
+    return (in, inδ)
+end
+
+function apply_back!(st, block::TimeEvolution{N}, collector) where N
+    out, outδ = st
+    adjblock = block'
+
+    out, outδ = st
+    in = apply!(out, adjblock)
+    for o in outδ
+        !all(x->x≈0.0im, o.state) && apply!(o, adjblock)
+    end
+    pushfirst!(collector, -sum(imag(in'*apply!(copy(outδ), block.H))))
+    return (in, outδ)
+end
+
+function apply_back!(st, block::PutBlock{N}, collector) where N
+    out, outδ = st
+    adjblock = block'
+    in = apply!(out, adjblock)
+    adjmat = outerprod(in, outδ)
+    mat_back!(datatype(in), block, adjmat, collector)
+    inδ = apply!(outδ, adjblock)
+    return (in, inδ)
+end
+
+function apply_back!(st, block::KronBlock{N}, collector) where N
+    apply_back!(st, chain(N, [put(loc=>block[loc]) for loc in block.locs]), collector)
+end
+
+function apply_back!(st, block::ControlBlock{N}, collector) where N
+    out, outδ = st
+    adjblock = block'
+    in = apply!(out, adjblock)
+    #adjm = adjcunmat(outerprod(in, outδ), N, block.ctrl_locs, block.ctrl_config, mat(content(block)), block.locs)
+    adjmat = outerprod(in, outδ)
+    mat_back!(datatype(in),block,adjmat,collector)
+    inδ = apply!(outδ, adjblock)
+    return (in, inδ)
+end
+
+function apply_back!(st, block::Daggered, collector)
+    out, outδ = st
+    adjblock = block'
+    in = apply!(out, adjblock)
+    adjmat = outerprod(outδ, in)
+    mat_back!(datatype(in), content(block),adjmat,collector)
+    inδ = apply!(outδ, adjblock)
+    return (in, inδ)
+end
+
+function apply_back!(st, block::Scale, collector)
+    out, outδ = st
+    apply_back!((out, outδ), content(block), collector)
+    outδ.state .= outδ.state .* conj(factor(block))
+    out.state .= out.state ./ factor(block)
+    return (out, outδ)
+end
+
+function apply_back!(st, circuit::ChainBlock, collector)
+    for blk in Base.Iterators.reverse(subblocks(circuit))
+        st = apply_back!(st, blk, collector)
+    end
+    return st
+end
+
+function apply_back!(st, circuit::Add, collector; in)
+    out, outδ = st
+    adjmat = outerprod(outδ, in)
+    for blk in Base.Iterators.reverse(subblocks(circuit))
+        mat_back!(datatype(in), blk, adjmat, collector)
+    end
+    inδ = apply!(outδ, adjblock)
+    (in, inδ)
+end
+
+function apply_back!(st, block::RepeatedBlock{N,C}, collector) where {N,C}
+    if nparameters(content(block)) == 0
+        return apply!.(st, Ref(block'))
+    end
+    res = Any[]
+    st = apply_back!(st, chain(N, [put(loc=>content(block)) for loc in block.locs]), res)
+    res = dropdims(sum(reshape(res, :,C), dims=2), dims=2)
+    prepend!(collector, res)
+    return st
+end
+
+# TODO: concentrator, repeat, kron
+apply_back!(st, block::Measure, collector) = throw(MethodError(apply_back!, (st, block, collector)))
+
+function backward_params!(st, block::Rotor, collector)
+    in, outδ = st
+    Σ = generator(block)
+    g = dropdims(sum(conj.(state(in |> Σ)) .* state(outδ), dims=(1,2)), dims=(1,2))
+    pushfirst!(collector, -imag(g)/2)
+    in |> Σ
+    nothing
+end
+
+"""
+    apply_back(st::Tuple{<:ArrayReg, <:ArrayReg}, block::AbstractBlock; kwargs...) -> (out, outδ), paramsδ
+
+The backward function of `apply!`. Returns a tuple of ((input register, gradient of input register), parameter gradients)
+"""
+function apply_back(st::Tuple{<:ArrayReg, <:ArrayReg}, block::AbstractBlock; kwargs...)
+    col=[]
+    in, inδ = apply_back!(st,block,col; kwargs...)
+    (in, inδ), col
+end
+
+Base.adjoint(::typeof(expect)) = Adjoint(expect)
+Base.show(io::IO, ::Adjoint{Any,typeof(expect)}) = print(io, "expect'")
+Base.show(io::IO, ::MIME"text/plain", ::Adjoint{Any,typeof(expect)}) = print(io, "expect'")
+"""
+expect')(op::AbstractBlock, circuit::Pair{<:ArrayReg, <:AbstractBlock})
+
+"""
+function (::Adjoint{Any,typeof(expect)})(op::AbstractBlock, circuit::Pair{<:ArrayReg, <:AbstractBlock})
+    reg, c = circuit
+    out = copy(reg) |> c
+    outδ = copy(out) |> op
+    (in, inδ), paramsδ = apply_back((out, outδ), c)
+    return outδ => paramsδ.*2
+end

--- a/src/autodiff/autodiff.jl
+++ b/src/autodiff/autodiff.jl
@@ -1,6 +1,6 @@
 module AD
 
-using BitBasis, YaoArrayRegister
+using BitBasis, YaoArrayRegister, YaoBase
 using ..YaoBlocks
 
 using SparseArrays, LuxurySparse, LinearAlgebra

--- a/src/autodiff/autodiff.jl
+++ b/src/autodiff/autodiff.jl
@@ -1,0 +1,16 @@
+module AD
+
+using BitBasis, YaoArrayRegister
+using ..YaoBlocks
+
+using SparseArrays, LuxurySparse, LinearAlgebra
+
+include("patches.jl")
+include("NoParams.jl")
+include("outerproduct_and_projection.jl")
+include("adjroutines.jl")
+include("mat_back.jl")
+include("apply_back.jl")
+include("gradcheck.jl")
+
+end

--- a/src/autodiff/gradcheck.jl
+++ b/src/autodiff/gradcheck.jl
@@ -1,0 +1,92 @@
+export mat_back_jacobian, apply_back_jacobian, ng
+export test_apply_back, test_mat_back
+
+function ng(f, θ, δ=1e-5)
+    res = []
+    for i=1:length(θ)
+        push!(res, (f(ireplace(θ, i=>θ[i]+δ/2)) - f(ireplace(θ, i=>θ[i]-δ/2)))/δ)
+    end
+    cat(res..., dims=3)
+end
+
+ireplace(vec::Vector, pair::Pair) = (v = copy(vec); v[pair.first] = pair.second; v)
+ireplace(vec::Number, pair::Pair) = pair.second
+
+function mat_back_jacobian(T, block, θ; use_outeradj=false)
+    dispatch!(block, θ)
+    m = mat(T, block)
+    N = size(m, 1)
+    jac = zeros(T, size(m)..., length(θ))
+    zm = use_outeradj ? OuterProduct(zeros(T,N), zeros(T,N)) : zero(m)
+    for j=1:size(m, 2)
+        @inbounds for i=1:size(m, 1)
+            if m[i,j]!=0
+                _setval(zm,i,j,1)
+                jac[i,j,:] = mat_back(ComplexF64, block, zm)
+                _setval(zm,i,j,1im)
+                jac[i,j,:] += 1im*mat_back(ComplexF64, block, zm)
+                _setval(zm,i,j,0)
+            end
+        end
+    end
+    return jac
+end
+_setval(m::AbstractMatrix, i, j, v) = (m[i,j]=v; m)
+_setval(m::OuterProduct, i, j, v) = (m.left[i] = v==0 ? 0 : 1; m.right[j]=v; m)
+Base.setindex!(m::PermMatrix, v, i,j) = m.perm[i] == j ? m.vals[i] = v : error()
+
+function apply_back_jacobian(reg0::ArrayReg{B}, block, θ; kwargs...) where B
+    dispatch!(block, θ)
+    out = apply!(copy(reg0), block)
+    m = out.state
+    zm = zero(m)
+    jac = zeros(eltype(m), size(m)..., length(θ))
+    for j=1:size(m, 2)
+        @inbounds for i=1:size(m, 1)
+            if m[i,j]!=0
+                zm[i,j] = 1
+                (in, inδ), col = apply_back((copy(out), ArrayReg{B}(copy(zm))), block; kwargs...)
+                @assert in ≈ reg0
+                jac[i,j,:] = col
+                zm[i,j] *= 1im
+                (in, inδ), col = apply_back((copy(out), ArrayReg{B}(copy(zm))), block)
+                jac[i,j,:] += 1im*col
+                zm[i,j] = 0
+            end
+        end
+    end
+    return jac
+end
+
+function test_mat_back(T, block::AbstractBlock{N}, param; δ=1e-5, use_outeradj::Bool=false) where N
+    function mfunc(param)
+        dispatch!(block, param)
+        mat(T, block)
+    end
+    # test loss is `real(sum(rand_matrix .* m))`
+    got = mat_back_jacobian(T, block, param; use_outeradj=use_outeradj)
+    num = ng(mfunc, param, δ)
+    res = isapprox(got, num, atol=10*δ)
+    if !res
+        @show size(got)
+        @show got
+        @show num
+    end
+    return res
+end
+
+function test_apply_back(reg0, block::AbstractBlock{N}, param; δ=1e-5, kwargs...) where N
+    function mfunc(param)
+        dispatch!(block, param)
+        apply!(copy(reg0), block).state
+    end
+    # test loss is `real(sum(rand_matrix .* m))`
+    got = apply_back_jacobian(reg0, block, param; kwargs...)
+    num = ng(mfunc, param, δ)
+    res = isapprox(got, num, atol=10*δ)
+    if !res
+        @show got
+        @show num
+    end
+    return res
+end

--- a/src/autodiff/mat_back.jl
+++ b/src/autodiff/mat_back.jl
@@ -1,0 +1,113 @@
+export mat_back!, mat_back
+############### Primitive
+"""
+The matrix gradient of a rotation block.
+"""
+@inline function rotgrad(::Type{T}, rb::RotationGate{N}) where {N, T}
+    -sin(rb.theta / 2)/2 * IMatrix{1<<N}() + im/2 * cos(rb.theta / 2) * conj(mat(T, rb.block))
+end
+
+function mat_back!(::Type{T}, rb::RotationGate{N, RT}, adjy, collector) where {T, N, RT}
+    pushfirst!(collector, projection(rb.theta, sum(adjy .* rotgrad(T, rb))))
+end
+
+function mat_back!(::Type{T}, rb::TimeEvolution{N}, adjy, collector) where {N,T}
+    pushfirst!(collector, projection(rb.dt, sum(im.*adjy .* conj.(mat(rb.H)*mat(rb)))))
+end
+
+function mat_back!(::Type{T}, A::GeneralMatrixBlock, adjy, collector) where T
+    pushfirst!(collector,adjy)
+end
+
+function mat_back!(::Type{T}, rb::PhaseGate, adjy, collector) where {T}
+    s = exp(-im*rb.theta)
+    res = -1im*(adjy[1,1]*s + adjy[2,2]*s)
+    pushfirst!(collector,projection(rb.theta, res))
+end
+
+function mat_back!(::Type{T}, rb::ShiftGate, adjy, collector) where {T}
+    res = -1im*adjy[2,2] * exp(-1im*rb.theta)
+    pushfirst!(collector, projection(rb.theta, res))
+end
+
+######################## Composite
+function mat_back!(::Type{T}, rb::AbstractBlock, adjy, collector) where T
+    nparameters(rb) == 0 && return collector
+    throw(MethodError(mat_back!, (T, rb, adjy, collector)))
+end
+
+function mat_back!(::Type{T}, rb::PutBlock{N, C, RT}, adjy, collector) where {T, N, C, RT}
+    nparameters(rb) == 0 && return collector
+    adjm = adjcunmat(adjy, N, (), (), mat(content(rb)), rb.locs)
+    mat_back!(T, content(rb), adjm, collector)
+end
+
+function mat_back!(::Type{T}, rb::Concentrator{N}, adjy, collector) where {T,N}
+    nparameters(rb) == 0 && return collector
+    adjm = adjcunmat(adjy, N, (), (), mat(content(rb)), rb.locs)
+    mat_back!(T, content(rb), adjm, collector)
+end
+
+function mat_back!(::Type{T}, rb::CachedBlock, adjy, collector) where T
+    mat_back!(T, content(rb), adjy, collector)
+end
+
+function mat_back!(::Type{T}, rb::Daggered, adjy, collector) where T
+    mat_back!(T, content(rb), adjy', collector)
+end
+
+function mat_back!(::Type{T}, rb::ControlBlock{N, C, RT}, adjy, collector) where {T, N, C, RT}
+    nparameters(rb) == 0 && return collector
+    adjm = adjcunmat(adjy, N, rb.ctrl_locs, rb.ctrl_config, mat(content(rb)), rb.locs)
+    mat_back!(T, content(rb), adjm, collector)
+end
+
+function mat_back!(::Type{T}, rb::ChainBlock{N}, adjy, collector) where {T,N}
+    np = nparameters(rb)
+    np == 0 && return collector
+    length(rb) == 1 && return mat_back!(T, rb[1], adjy, collector)
+
+    mi = mat(rb[1])
+    cache = Any[mi]
+    for b in rb[2:end-1]
+        mi = mat(b)*mi
+        push!(cache, mi)
+    end
+    adjb = adjy * cache[end]'
+    for ib in length(rb):-1:1
+        b = rb[ib]
+        #adjb = ib==1 ? adjy : adjy*cache[ib]'
+        mat_back!(T, b, adjb, collector)
+        ib!=1 && (adjb = mat(b)'*adjb*mat(rb[ib-1]))
+    end
+    return collector
+end
+
+function mat_back!(::Type{T}, rb::KronBlock{N}, adjy, collector) where {T,N}
+    nparameters(rb) == 0 && return collector
+    mat_back!(T, chain(N, [put(loc=>rb[loc]) for loc in rb.locs]), adjy, collector)
+    return collector
+end
+
+function mat_back!(::Type{T}, rb::Add{N}, adjy, collector) where {T,N}
+    nparameters(rb) == 0 && return collector
+    for b in subblocks(rb)[end:-1:1]
+        mat_back!(T, b, adjy, collector)
+    end
+    return collector
+end
+
+function mat_back!(::Type{T}, rb::Scale{N}, adjy, collector) where {T,N}
+    np = nparameters(rb)
+    np == 0 && return collector
+    mat_back!(T, content(rb), factor(rb)*adjy, collector)
+    return collector
+end
+
+"""
+    mat_back([::Type{T}, ]block::AbstractBlock, adjm::AbstractMatrix) -> Vector
+
+The backward function of `mat`. Returns the gradients of parameters.
+"""
+mat_back(block::AbstractBlock, adjm::AbstractMatrix) = mat_back!(ComplexF64, block, adjm, [])
+mat_back(::Type{T}, block::AbstractBlock, adjm::AbstractMatrix) where T = mat_back!(T, block, adjm, [])

--- a/src/autodiff/outerproduct_and_projection.jl
+++ b/src/autodiff/outerproduct_and_projection.jl
@@ -1,0 +1,78 @@
+export LowRankMatrix, OuterProduct, projection, outerprod
+abstract type LowRankMatrix{T} <: AbstractMatrix{T} end
+
+"""
+    OuterProduct{T,AT<:AbstractArray{T}} <: LowRankMatrix{T}
+
+If `AT <: AbstractVector`, it represents an outer product `x.left*transpose(x.right)`.
+Else if `AT <: AbstractMatrix`, then it is an outer product `x.left*transpose(x.right)`.
+"""
+struct OuterProduct{T,AT<:AbstractArray{T}} <: LowRankMatrix{T}
+    left::AT
+    right::AT
+end
+
+function OuterProduct(left::AT, right::AT) where {T,AT<:AbstractMatrix{T}}
+    size(left[2]) != size(right[2]) && throw(DimensionMismatch("The seconds dimension of left ($(size(left,2))) and right $(size(right,2)) does not match."))
+    return OuterProduct{T,AT}(left, right)
+end
+
+const BatchedOuterProduct{T,MT} = OuterProduct{T,MT} where MT<:AbstractMatrix
+const SimpleOuterProduct{T,VT} = OuterProduct{T,VT} where VT<:AbstractVector
+
+LinearAlgebra.rank(op::OuterProduct) = size(op.left, 2)
+Base.getindex(op::OuterProduct{T,<:AbstractVector}, i::Int, j::Int) where T = op.left[i]*op.right[j]
+Base.getindex(op::BatchedOuterProduct, i::Int, j::Int) = sum(k->op.left[i,k]*op.right[j,k], 1:rank(op))
+Base.size(op::OuterProduct) = (size(op.left,1), size(op.right,1))
+Base.size(op::OuterProduct, i::Int) = i==1 ? size(op.left,1) : (i==2 ? size(op.right,1) : throw(DimensionMismatch("")))
+
+LinearAlgebra.mul!(a::OuterProduct, b) = a.left * (transpose(a.right)*b)
+LinearAlgebra.mul!(a::OuterProduct, b::AbstractMatrix) = OuterProduct(a.left, transpose(transpose(a.right)*b))
+LinearAlgebra.mul!(a, b::OuterProduct) = (a*b.left) * transpose(b.right)
+LinearAlgebra.mul!(a::AbstractMatrix, b::OuterProduct) = OuterProduct(a*b.left, b.right)
+LinearAlgebra.mul!(a::OuterProduct, b::OuterProduct) = OuterProduct(a.left*(transpose(a.right)*b.left), b.right)
+
+Base.conj!(op::OuterProduct) = OuterProduct(conj!(op.left), conj!(op.right))
+Base.transpose(op::OuterProduct) = OuterProduct(op.right, op.left)
+Base.adjoint(op::OuterProduct) = OuterProduct(conj(op.right), conj(op.left))
+
+outerprod(left::AbstractVector, right::AbstractVector) = OuterProduct(left, right)
+outerprod(left::AbstractMatrix, right::AbstractMatrix) = OuterProduct(left, right)
+outerprod(in::ArrayReg{1}, outδ::ArrayReg{1}) = outerprod(conj(statevec(in)), statevec(outδ))
+outerprod(in::ArrayReg{B}, outδ::ArrayReg{B}) where B = outerprod(conj(statevec(in)), statevec(outδ))
+
+
+"""
+    projection(y::AbstractMatrix, op::AbstractMatrix) -> typeof(y)
+
+Project `op` to sparse matrix with same sparsity as `y`.
+"""
+function projection(y::AbstractMatrix, op::AbstractMatrix)
+    size(y) == size(op) || throw(DimensionMismatch("can not project a matrix of size $(size(op)) to target size $(size(y))"))
+    out = zero(y)
+    unsafe_projection!(out, op)
+end
+
+unsafe_projection!(y::Diagonal, m::AbstractMatrix) = (y.diag .= diag(m); y)
+unsafe_projection!(y::Diagonal, op::OuterProduct) = (y.diag .+= op.left .* op.right; y)
+
+unsafe_projection!(y::Matrix, adjy, v) = y .+= adjy.*v
+
+@inline function unsafe_projection!(y::AbstractSparseMatrix, m::AbstractMatrix)
+    is, js, vs = findnz(y)
+    for (k,(i,j)) in enumerate(zip(is, js))
+        @inbounds y.nzval[k] += m[i,j]
+    end
+    y
+end
+
+@inline function unsafe_projection!(y::PermMatrix, m::AbstractMatrix)
+    for i=1:size(y, 1)
+        @inbounds y.vals[i] = m[i,y.perm[i]]
+    end
+    y
+end
+
+projection(x::RT, adjx::Complex) where RT<:Real = RT(real(adjx))
+projection(x::T, y::T) where T = y
+projection(x::T1, y::T2) where {T1, T2} = convert(T1, y)

--- a/src/autodiff/patches.jl
+++ b/src/autodiff/patches.jl
@@ -1,0 +1,10 @@
+Base.zero(pm::PermMatrix) = PermMatrix(pm.perm, zero(pm.vals))
+
+# TODO
+# to make a mat block differentiable
+#YaoBlocks.niparams(x::GeneralMatrixBlock{N,N}) where N = 1<<2N
+#YaoBlocks.getiparams(x::GeneralMatrixBlock) where N = (vec(x.mat)...,)
+
+# to make a scale block differentiable
+#YaoBlocks.niparams(x::Scale{<:Number}) = 1
+#YaoBlocks.getiparams(x::Scale{<:Number}) = factor(x)

--- a/test/autodiff/NoParams.jl
+++ b/test/autodiff/NoParams.jl
@@ -1,0 +1,19 @@
+using Test
+using YaoBlocks.AD
+using YaoBlocks
+using YaoArrayRegister
+
+@testset "NoParams" begin
+    c = chain(put(3, 2=>Ry(0.2)), put(3, 1=>Rx(0.5)))
+    np = chain(NoParams(put(3, 2=>Ry(0.2))), put(3, 1=>Rx(0.5)))
+    reg = rand_state(3)
+    @test content(np[1]) == put(3, 2=>Ry(0.2))
+    @test parameters(np) == [0.5]
+    @test nparameters(np) == 1
+    @test getiparams(np[1]) == ()
+    @test niparams(np[1]) == 0
+    @test mat(c) ≈ mat(np)
+    @test apply!(copy(reg), c) ≈ apply!(copy(reg), np)
+    @test np' == chain(put(3, 1=>Rx(-0.5)), NoParams(put(3, 2=>Ry(-0.2))))
+    @test dispatch!(np, [0.3]) == chain(NoParams(put(3, 2=>Ry(0.2))), put(3, 1=>Rx(0.3)))
+end

--- a/test/autodiff/apply_back.jl
+++ b/test/autodiff/apply_back.jl
@@ -1,0 +1,84 @@
+using Test
+using YaoBlocks.AD
+using YaoBlocks
+using Random
+
+@testset "apply put" begin
+    Random.seed!(5)
+    for reg0 in [rand_state(3), rand_state(3, nbatch=10)]
+        # put block, diagonal
+        @test test_apply_back(reg0, put(3, 1=>shift(0.5)), 0.5; δ=1e-5)
+        @test test_apply_back(reg0, control(3, (2,3), 1=>Rz(0.5)), 0.5; δ=1e-5)
+        @test test_apply_back(reg0, control(3, 2, 1=>shift(0.5)), 0.5; δ=1e-5)
+        # dense matrix
+        @test test_apply_back(reg0, put(3, 1=>cache(Rx(0.5))), 0.5; δ=1e-5)
+        @test test_apply_back(reg0, control(3, (2,3), 1=>Rx(0.5)), 0.5; δ=1e-5)
+        # sparse matrix csc
+        @test test_apply_back(reg0, put(3, (1,2)=>rot(SWAP, 0.5)), 0.5; δ=1e-5)
+        @test test_apply_back(reg0, control(3, (3,), (1,2)=>rot(SWAP, 0.5)), 0.5; δ=1e-5)
+
+        # special cases: DiffBlock
+        @test test_apply_back(reg0, put(3, 1=>Rz(0.5)), 0.5; δ=1e-5)
+        @test test_apply_back(reg0, put(3, 1=>Rx(0.5)), 0.5; δ=1e-5)
+        @test test_apply_back(rand_state(1), Rx(0.0), 0.5; δ=1e-5)
+
+        # TimeEvolution
+        @test test_apply_back(reg0, TimeEvolution(put(3, 1=>X), 0.5), 0.5; δ=1e-5)
+    end
+end
+
+@testset "apply chain" begin
+    Random.seed!(5)
+    for reg0 in [rand_state(3), rand_state(3, nbatch=10)]
+        @test test_apply_back(reg0, chain(3, put(3, 1=>shift(0.0)), control(3, (2,3), 1=>Rz(0.0))), [0.5,0.5]; δ=1e-5)
+        c = chain(3, put(3, 1=>shift(0.0)), NoParams(control(3, (2,3), 1=>Rz(0.0))))
+        @test nparameters(c) == 1
+        @test test_apply_back(reg0, c, 0.5; δ=1e-5)
+    end
+end
+
+@testset "apply dagger, scale" begin
+    Random.seed!(5)
+    for reg0 in [rand_state(3), rand_state(3, nbatch=10)]
+        @test test_apply_back(reg0, chain(put(3, 1=>Rx(0.0)), (3+2im)*control(3, (2,3), 1=>Rz(0.0))), [0.5,0.5]; δ=1e-5)
+        @test test_apply_back(reg0, Daggered(put(3, 1=>Rx(0.0))), 0.5; δ=1e-5)
+        @test test_apply_back(reg0, control(3, (2,3), 1=>Daggered(Rz(0.0))), 0.5; δ=1e-5)
+        @test test_apply_back(reg0, chain(3, Daggered(put(3, 1=>Rx(0.0))), control(3, (2,3), 1=>Daggered(Rz(0.0)))), [0.5,0.5]; δ=1e-5)
+    end
+end
+
+@testset "apply concentrate" begin
+    Random.seed!(5)
+    for reg0 in [rand_state(3), rand_state(3, nbatch=10)]
+        @test test_apply_back(reg0, chain(3,  put(3, 1=>Rx(0.0)), concentrate(3, control(2, 2,1=>shift(0.0)), (3,1))), [0.5,0.5]; δ=1e-5)
+    end
+end
+
+@testset "apply kron repeated" begin
+    Random.seed!(5)
+    for reg0 in [rand_state(3), rand_state(3, nbatch=10)]
+        @test test_apply_back(reg0, chain(3, put(3, 1=>Rx(0.0)), kron(Rx(0.4), Y, Rz(0.5))), [0.5,0.3, 0.8]; δ=1e-5)
+        @test test_apply_back(reg0, chain(repeat(3, Rx(0.5), 1:2), repeat(3, Ry(0.6), 2:3)), [0.5, 0.8]; δ=1e-5)
+        @test test_apply_back(reg0, chain(repeat(3, H, 1:2), repeat(3, Ry(0.6), 2:3)), [0.8]; δ=1e-5)
+    end
+end
+
+@testset "apply Add" begin
+    # + is not reversible
+    for reg0 in [rand_state(3), rand_state(3, nbatch=10)]
+        @test_broken test_apply_back(reg0, (3*control(3, (2,3), 1=>Rz(0.0))+put(3,2=>Rx(0.0)))/5, [0.5,0.5]; δ=1e-5, in=copy(reg0))
+    end
+end
+
+A(i, j) = control(i, j=>shift(2π/(1<<(i-j+1))))
+B(n, i) = chain(n, i==j ? put(i=>H) : A(j, i) for j in i:n)
+qft(n) = chain(B(n, i) for i in 1:n)
+
+@testset "system test" begin
+    nbit = 4
+    c = qft(nbit)
+    H = repeat(nbit, X, 1:nbit)
+    adjin, adjparams = expect'(H, zero_state(nbit)=>c)
+    numgrad = YaoBlocks.AD.ng(x->expect(H, zero_state(nbit) |> dispatch!(c, x)), parameters(c))
+    @test adjparams ≈ vec(numgrad)
+end

--- a/test/autodiff/apply_back.jl
+++ b/test/autodiff/apply_back.jl
@@ -1,6 +1,6 @@
 using Test
 using YaoBlocks.AD
-using YaoBlocks
+using YaoBlocks, YaoArrayRegister
 using Random
 
 @testset "apply put" begin
@@ -70,8 +70,8 @@ end
     end
 end
 
-A(i, j) = control(i, j=>shift(2π/(1<<(i-j+1))))
-B(n, i) = chain(n, i==j ? put(i=>H) : A(j, i) for j in i:n)
+AA(i, j) = control(i, j=>shift(2π/(1<<(i-j+1))))
+B(n, i) = chain(n, i==j ? put(i=>H) : AA(j, i) for j in i:n)
 qft(n) = chain(B(n, i) for i in 1:n)
 
 @testset "system test" begin

--- a/test/autodiff/autodiff.jl
+++ b/test/autodiff/autodiff.jl
@@ -1,0 +1,22 @@
+using YaoBlocks.AD, YaoBlocks
+using Test
+
+@testset "patches" begin
+    include("patches.jl")
+end
+
+@testset "outerproduct_and_projection" begin
+    include("outerproduct_and_projection.jl")
+end
+
+@testset "NoParams" begin
+    include("NoParams.jl")
+end
+
+@testset "apply_back" begin
+    include("apply_back.jl")
+end
+
+@testset "mat_back" begin
+    include("mat_back.jl")
+end

--- a/test/autodiff/mat_back.jl
+++ b/test/autodiff/mat_back.jl
@@ -1,0 +1,59 @@
+using Test
+using YaoBlocks.AD, YaoBlocks
+using YaoArrayRegister
+using Random
+
+using SparseArrays, LuxurySparse, LinearAlgebra
+
+@testset "mat rot/shift/phase" begin
+    Random.seed!(5)
+    for G in [X, Y, Z, ConstGate.SWAP, ConstGate.CZ, ConstGate.CNOT]
+        @test test_mat_back(ComplexF64, rot(G, 0.0), 0.5; δ=1e-5)
+    end
+
+    for G in [ShiftGate, PhaseGate]
+        @test test_mat_back(ComplexF64, G(0.0), 0.5; δ=1e-5)
+    end
+
+    G = time_evolve(put(3, 2=>X), 0.0)
+    @test test_mat_back(ComplexF64, G, 0.5; δ=1e-5)
+end
+
+@testset "mat put block, control block" begin
+    Random.seed!(5)
+    for use_outeradj in [false, true]
+        # put block, diagonal
+        @test test_mat_back(ComplexF64, put(3, 1=>Rz(0.5)), 0.5; δ=1e-5, use_outeradj=use_outeradj)
+        @test test_mat_back(ComplexF64, control(3, (2,3), 1=>Rz(0.5)), 0.5; δ=1e-5, use_outeradj=use_outeradj)
+        # dense matrix
+        @test test_mat_back(ComplexF64, put(3, 1=>Rx(0.5)), 0.5; δ=1e-5, use_outeradj=use_outeradj)
+        @test test_mat_back(ComplexF64, control(3, (2,3), 1=>Rx(0.5)), 0.5; δ=1e-5, use_outeradj=use_outeradj)
+        # sparse matrix csc
+        @test test_mat_back(ComplexF64, put(3, (1,2)=>rot(SWAP, 0.5)), 0.5; δ=1e-5, use_outeradj=use_outeradj)
+        @test test_mat_back(ComplexF64, control(3, (3,), (1,2)=>rot(SWAP, 0.5)), 0.5; δ=1e-5, use_outeradj=use_outeradj)
+    end
+
+    # is permatrix even possible?
+    #@test test_mat_back(ComplexF64, put(3, 1=>matblock(pmrand(2))), [0.5, 0.6]; δ=1e-5)
+    # ignore identity matrix.
+end
+
+@testset "mat concentrate" begin
+    Random.seed!(5)
+    @test test_mat_back(ComplexF64, concentrate(3, control(2, 2,1=>shift(0.0)), (3,1)), 0.5; δ=1e-5)
+end
+
+@testset "mat chain" begin
+    Random.seed!(5)
+    @test test_mat_back(ComplexF64, chain(3, control(3, 2,1=>shift(0.0))), 0.5; δ=1e-5)
+    @test test_mat_back(ComplexF64, chain(3, put(3, 2=>X), control(3, 2,1=>shift(0.0))), 0.5; δ=1e-5)
+    @test test_mat_back(ComplexF64, chain(3, control(3, 2,1=>shift(0.0)), put(3, 2=>X)), 0.5; δ=1e-5)
+    @test test_mat_back(ComplexF64, chain(3, control(3, 2,1=>shift(0.0)), NoParams(put(3, 1=>Rx(0.0)))), 0.5; δ=1e-5)
+    @test test_mat_back(ComplexF64, chain(3, control(3, 2,1=>shift(0.0)), chain(put(3, 1=>Rx(0.0)), put(3, 2=>Ry(0.0)))), [0.5,0.5,0.5]; δ=1e-5)
+    @test test_mat_back(ComplexF64, chain(3, chain(3, put(3, 1=>Rx(0.0)), put(3, 2=>Ry(0.0)))), [0.5,0.5]; δ=1e-5)
+end
+
+@testset "mat kron" begin
+    use_outeradj=false
+    @test test_mat_back(ComplexF64, kron(Rx(0.5), Rz(0.6)), [0.5, 0.5]; δ=1e-5, use_outeradj=use_outeradj)
+end

--- a/test/autodiff/outerproduct_and_projection.jl
+++ b/test/autodiff/outerproduct_and_projection.jl
@@ -1,0 +1,40 @@
+using YaoBlocks.AD
+using SparseArrays, LuxurySparse
+using YaoArrayRegister
+using Test
+
+@testset "outer prod" begin
+    D = 8
+    T = ComplexF64
+    for (l, r) in [(randn(T,D), randn(T,D)), (randn(T,D, 3), randn(T,D, 3))]
+        a = outerprod(l, r)
+        A = Matrix(a)
+        B = randn(T,D,D)
+        V = randn(T,D)
+        @test A * B ≈ a*B
+        @test A * A ≈ a*a
+        @test B * A ≈ B*a
+        @test V' * A ≈ V'*a
+        @test A * V ≈ a*V
+        @test size(a) == size(A)
+        @test size(a,2) == size(A,2)
+        @test A[4] == a[4]
+        @test A[4,4] == a[4,4]
+        @test A' == a'
+        @test transpose(A) == transpose(a)
+        @test conj(A) == conj(a)
+        @test conj!(A) == conj!(a)
+        outerprod(ArrayReg(l), ArrayReg(r)) == a
+    end
+end
+
+@testset "projection" begin
+    T = ComplexF64
+    D = 8
+    for y in [pmrand(T,D), sprand(T, D, D, 0.5), Diagonal(randn(T,D))]
+        @test projection(y, y) == y
+        l, r = randn(T,D), randn(T,D)
+        op = outerprod(l, r)
+        @test projection(y, op) == projection(y, Matrix(op))
+    end
+end

--- a/test/autodiff/patches.jl
+++ b/test/autodiff/patches.jl
@@ -1,0 +1,13 @@
+using YaoBlocks, LuxurySparse, SparseArrays, LinearAlgebra
+using YaoBlocks.AD
+using Test, Random
+
+@testset "zero rand!" begin
+    T = ComplexF64
+    D = 10
+    Random.seed!(2)
+    for pm = [pmrand(T, D), Diagonal(randn(T, D)), sprand(T, D,D,0.4)]
+        z = zero(pm)
+        @test z == zeros(D,D)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,10 @@ end
     include("extending_reg.jl")
 end
 
+@testset "autodiff" begin
+    include("autodiff/autodiff.jl")
+end
+
 # @testset "test demos" begin
 #     include("algo/qft.jl")
 #     include("algo/qcbm.jl")


### PR DESCRIPTION
```
using YaoExtetions, Yao
nbit = 4
c = variational_circuit(nbit)
H = repeat(nbit, X, 1:nbit)
adjin, adjparams = expect'(H, zero_state(nbit)=>c)
```
1. Two API for porting AD frameworks

* `mat_back!`
* `apply_back!`

2. An easy to use API

* `expect'(hamiltonian, reg=>circuit)`, returns the gradient of register and circuit parameters.

TODO:
Some performance improvements.