### PR TITLE
add support to pair in chain

### DIFF
--- a/src/blocktools.jl
+++ b/src/blocktools.jl
@@ -1,5 +1,6 @@
 using YaoBase: @interface
 
+parse_block(n::Int, ex) = throw(Meta.ParseError("cannot parse expression $ex, expect a pair or quantum block"))
 parse_block(n::Int, x::Function) = x(n)
 
 function parse_block(n::Int, x::AbstractBlock{N}) where N

--- a/src/blocktools.jl
+++ b/src/blocktools.jl
@@ -8,7 +8,14 @@ function parse_block(n::Int, x::AbstractBlock{N}) where N
 end
 
 # if it is a single qubit pair, parse it to put block
-parse_block(n::Int, x::Pair{Int, <:AbstractBlock{N}}) where N = put(n, x)
+parse_block(n::Int, x::Pair{Int, <:AbstractBlock}) = put(n, x)
+# infer the number of qubits if the inner function was curried
+parse_block(n::Int, x::Pair{Int, <:Function}) = put(n, x.first=>parse_block(1, x.second))
+
+# error if it is not single qubit case
+function parse_block(n::Int, x::Pair)
+    throw(Meta.ParseError("please specifiy the block type of $x, consider to use concentrate for large block in local scope."))
+end
 
 """
     prewalk(f, src::AbstractBlock)

--- a/src/blocktools.jl
+++ b/src/blocktools.jl
@@ -7,7 +7,8 @@ function parse_block(n::Int, x::AbstractBlock{N}) where N
     return x
 end
 
-parse_block(n::Int, x::Pair{Int, <:AbstractBlock{N}}) where N = x
+# if it is a single qubit pair, parse it to put block
+parse_block(n::Int, x::Pair{Int, <:AbstractBlock{N}}) where N = put(n, x)
 
 """
     prewalk(f, src::AbstractBlock)

--- a/src/composite/chain.jl
+++ b/src/composite/chain.jl
@@ -49,6 +49,7 @@ function chain(n::Int, block::AbstractBlock)
 end
 chain(blocks::Function...) = @λ(n -> chain(n, blocks...))
 chain(it) = chain(it...) # forward iterator to vargs, so we could dispatch based on types
+chain(it::Pair) = error("got $it, do you mean put($it)?")
 chain(blocks...) = @λ(n -> chain(n, blocks))
 
 """

--- a/src/composite/chain.jl
+++ b/src/composite/chain.jl
@@ -38,6 +38,9 @@ end
 # if not all matrix block, try to put the number of qubits.
 chain(n::Int, blocks...) = chain(map(x->parse_block(n, x), blocks)...)
 chain(n::Int, itr) = isempty(itr) ? chain(n) : chain(map(x->parse_block(n, x), itr)...)
+# disambiguity
+# NOTE: we use parse_block here to make sure the behaviour are the same
+chain(n::Int, it::Pair) = chain(n, parse_block(n, it))
 chain(n::Int, f::Function) = chain(n, parse_block(n, f))
 function chain(n::Int, block::AbstractBlock)
     @assert n == nqubits(block) "number of qubits mismatch"

--- a/src/composite/kron.jl
+++ b/src/composite/kron.jl
@@ -103,10 +103,16 @@ function Base.kron(total::Int, blocks::AbstractBlock...)
     return kron(blocks...)
 end
 
-Base.kron(total::Int, blocks::Union{AbstractBlock, Pair}...) =
-    error("location of sparse distributed blocks must be explicit declared with pair (e.g 2=>X)")
-
 Base.kron(total::Int, blocks::Base.Generator) = kron(total, blocks...)
+
+# handling errors
+Base.kron(blocks::Union{AbstractBlock, Pair{Int, <:AbstractBlock}}...) =
+    error("location of sparse distributed blocks must be explicit declared with pair (e.g 2=>X)")
+Base.kron(total::Int, blocks::Union{AbstractBlock, Pair{Int, <:AbstractBlock}}...) = kron(blocks...)
+Base.kron(blocks::Union{AbstractBlock, Pair{<:AbstractRange, <:AbstractBlock}}...) =
+    error("kron only supports contiguous location, specifiy the first qubit location with an integer, e.g kron(4, 2=>control(2, 2, 1=>X))")
+Base.kron(total::Int, blocks::Union{AbstractBlock, Pair{<:AbstractRange, <:AbstractBlock}}...) =
+    kron(blocks...)
 
 """
     kron(blocks...) -> f(n)

--- a/test/composite/chain.jl
+++ b/test/composite/chain.jl
@@ -43,6 +43,10 @@ end
 
     @test chain(4, 1=>X) == chain(4, put(1=>X))
     @test chain(4, put(1=>X), 3=>X) == chain(4, put(1=>X), 3=>X)
+
+    # this is really a corner case, but I think it make sense to work
+    @test chain(1=>chain()) == chain(1, chain(1))
+    @test_throws Meta.ParseError chain(4, 2:3=>kron(X, X))
 end
 
 @testset "#15" begin

--- a/test/composite/chain.jl
+++ b/test/composite/chain.jl
@@ -40,6 +40,9 @@ end
     @test chain(put(1=>X))(4) == chain(put(4, 1=>X))
     @test chain(put(1=>X), put(2=>X))(4) == chain(put(4, 1=>X), put(4, 2=>X))
     @test chain()(4) == chain(4)
+
+    @test chain(4, 1=>X) == chain(4, put(1=>X))
+    @test chain(4, put(1=>X), 3=>X) == chain(4, put(1=>X), 3=>X)
 end
 
 @testset "#15" begin

--- a/test/composite/chain.jl
+++ b/test/composite/chain.jl
@@ -39,12 +39,11 @@ end
     @test chain(put(1 => X), put(2 => X))(4) == chain(put(4, 1 => X), put(4, 2 => X))
     @test chain()(4) == chain(4)
 
-    @test chain(4, 1=>X) == chain(4, put(1=>X))
-    @test chain(4, put(1=>X), 3=>X) == chain(4, put(1=>X), 3=>X)
+    @test_throws ErrorException chain(4, 1=>X)
+    @test_throws ErrorException chain(4, put(1=>X), 3=>X)
 
-    # this is really a corner case, but I think it make sense to work
-    @test chain(1=>chain()) == chain(1, chain(1))
-    @test_throws Meta.ParseError chain(4, 2:3=>kron(X, X))
+    @test_throws ErrorException chain(1=>chain())
+    @test_throws ErrorException chain(4, 2:3=>kron(X, X))
 end
 
 @testset "#15" begin

--- a/test/composite/kron.jl
+++ b/test/composite/kron.jl
@@ -29,6 +29,7 @@ end
 @testset "test constructors" begin
     @test_throws LocationConflictError KronBlock{5}(4=>CNOT, 5=>X)
     @test_throws ErrorException kron(3, 1=>X, Y)
+    @test_throws ErrorException kron(1:2=>kron(X, Y), Y)
 end
 
 @testset "test mat" begin


### PR DESCRIPTION
this make the syntax a bit simpler

old:

```jl
chain(put(1=>X), put(3=>X), put(2=>Y))
```

new:

```jl
chain(1=>X, 3=>X, 2=>Y)
```

although this breaks the definition that all the subblocks of chain has the same number of qubits from the semantic (since the block boundary is not specified explicitly) but I think for single qubit case this make it more convenient from the interface aspect.

the old one might be a bit confusing (cc: @artix41) when we support pairs in `put`, `control`, `kron` etc. but not chain.