### PR TITLE
WIP: integration with ChainRules & Zygote

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,10 @@ version = "0.6.0"
 [deps]
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
 CacheServers = "a921213e-d44a-5460-ac04-5d720a99ba71"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18"
-LegibleLambdas = "f1f30506-32fe-5131-bd72-7c197988f9e5"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+LegibleLambdas = "f1f30506-32fe-5131-bd72-7c197988f9e5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LuxurySparse = "d05aeea4-b7d4-55ac-b691-9e7fabb07ba2"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
@@ -18,12 +19,13 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
 YaoBase = "a8f54c17-34bc-5a9d-b050-f522fe3f755f"
+ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
-julia = "^1.0.0"
-YaoBase = "~0.11.1"
-YaoArrayRegister = "~0.4.0"
 BitBasis = "~0.6"
+YaoArrayRegister = "~0.4.0"
+YaoBase = "~0.11.1"
+julia = "^1.0.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/autodiff/apply_back.jl
+++ b/src/autodiff/apply_back.jl
@@ -157,17 +157,18 @@ function apply_back(st::Tuple{<:ArrayReg, <:ArrayReg}, block::AbstractBlock; kwa
     (in, inδ), col
 end
 
-Base.adjoint(::typeof(expect)) = Adjoint(expect)
-Base.show(io::IO, ::Adjoint{Any,typeof(expect)}) = print(io, "expect'")
-Base.show(io::IO, ::MIME"text/plain", ::Adjoint{Any,typeof(expect)}) = print(io, "expect'")
-"""
-expect')(op::AbstractBlock, circuit::Pair{<:ArrayReg, <:AbstractBlock})
+# Base.adjoint(::typeof(expect)) = Adjoint(expect)
+# Base.show(io::IO, ::Adjoint{Any,typeof(expect)}) = print(io, "expect'")
+# Base.show(io::IO, ::MIME"text/plain", ::Adjoint{Any,typeof(expect)}) = print(io, "expect'")
 
-"""
-function (::Adjoint{Any,typeof(expect)})(op::AbstractBlock, circuit::Pair{<:ArrayReg, <:AbstractBlock})
-    reg, c = circuit
-    out = copy(reg) |> c
-    outδ = copy(out) |> op
-    (in, inδ), paramsδ = apply_back((out, outδ), c)
-    return outδ => paramsδ.*2
-end
+# """
+# expect')(op::AbstractBlock, circuit::Pair{<:ArrayReg, <:AbstractBlock})
+
+# """
+# function (::Adjoint{Any,typeof(expect)})(op::AbstractBlock, circuit::Pair{<:ArrayReg, <:AbstractBlock})
+#     reg, c = circuit
+#     out = copy(reg) |> c
+#     outδ = copy(out) |> op
+#     (in, inδ), paramsδ = apply_back((out, outδ), c)
+#     return outδ => paramsδ.*2
+# end

--- a/src/blocktools.jl
+++ b/src/blocktools.jl
@@ -79,6 +79,10 @@ function expect(op::Scale, reg::AbstractRegister)
     factor(op)*expect(content(op), reg)
 end
 
+function expect(op, plan::Pair{<:AbstractRegister, <:AbstractBlock})
+    expect(op, plan.first |> plan.second)
+end
+
 expect(op::Add, reg::AbstractRegister{1}) = invoke(expect, Tuple{Add, AbstractRegister}, op, reg)
 expect(op::Scale, reg::AbstractRegister{1}) = invoke(expect, Tuple{Scale, AbstractRegister}, op, reg)
 


### PR DESCRIPTION
I'll implement the following

- [ ] ChainRules compatible `rrule` for `apply` and `mat`
- [ ] dispatch ChainRules to `ZygoteRules` (since https://github.com/FluxML/Zygote.jl/pull/291 is merged yet)
- [ ] polish the interface a bit (`expect'` will be removed for compatibility reason, but after this PR is merged, users should be able to call other AD package with their native syntax sugar which is composable with classical functions)

note this won't add deps to Zygote. only two lightweight API deps will be added.