### PR TITLE
Support Pattern Matching

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,10 @@ version = "0.6.0"
 [deps]
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
 CacheServers = "a921213e-d44a-5460-ac04-5d720a99ba71"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18"
-LegibleLambdas = "f1f30506-32fe-5131-bd72-7c197988f9e5"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+LegibleLambdas = "f1f30506-32fe-5131-bd72-7c197988f9e5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LuxurySparse = "d05aeea4-b7d4-55ac-b691-9e7fabb07ba2"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
@@ -20,10 +21,10 @@ YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
 YaoBase = "a8f54c17-34bc-5a9d-b050-f522fe3f755f"
 
 [compat]
-julia = "^1.0.0"
-YaoBase = "~0.11.1"
-YaoArrayRegister = "~0.4.0"
 BitBasis = "~0.6"
+YaoArrayRegister = "~0.4.0"
+YaoBase = "~0.11.1"
+julia = "^1.0.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/abstract_block.jl
+++ b/src/abstract_block.jl
@@ -6,9 +6,9 @@ import YaoBase: @interface
 export nqubits, isreflexive, isunitary, ishermitian
 
 """
-    AbstractBlock
+    AbstractBlock{N}
 
-Abstract type for quantum circuit blocks.
+Abstract type for quantum circuit blocks. `N` is the number of qubits.
 """
 abstract type AbstractBlock{N} end
 

--- a/src/treeutils/match.jl
+++ b/src/treeutils/match.jl
@@ -1,0 +1,336 @@
+export BlockVar, BlockMatch, var
+# we will overload a lot match
+# so I just import it here
+import Base: match
+
+# part of the design is shamelessly taken from simplify
+# but we extend it for quantum circuit here, we can and should make
+# use of Harrison's incoming Rewrite engine in the future to reduce
+# duplications.
+#
+# I (Roger-luo) thank Harrison Grodin, Mason Potter and thautwarm 's
+# helpful disscussion on symbolic manipulation and pattern matching
+
+struct BlockVar{N} <: PrimitiveBlock{N}
+    name::Symbol
+end
+
+BlockVar(n::Int) = BlockVar{n}(gensym())
+occupied_locs(::BlockVar{N}) where N = Tuple(1:N)
+subblocks(::BlockVar) = ()
+
+"""
+    isvar(x)
+
+Check if `x` is a variable.
+"""
+isvar(x::BlockVar) = true
+isvar(x) = false
+
+"""
+    var(n::Int[, name=gensym()])
+
+Create a [`BlockVar`](@ref) by given number of qubits. A `BlockVar`
+can be used to create quantum circuit patterns.
+
+# Example
+
+```jldoctest
+julia> x = var(1, :x)
+var(1, :x)
+
+julia> match(chain(x, x), chain(X, X))
+BlockMatch
+Match 1
+var(1, :x) matches
+X gate
+```
+
+See also [`match`](@ref).
+"""
+var(n::Int, name::Symbol=gensym()) = BlockVar{n}(name)
+
+"""
+    var(name::Symbol)
+
+Curried version of `var(n, name)` on the number of qubits.
+
+```jldoctest
+julia> var(:x)
+(n -> var(n, x))
+```
+"""
+var(name::Symbol) = @λ(n -> var(n, name))
+
+print_block(io::IO, g::BlockVar{N}) where N = print(io, "var(", N, ", ", QuoteNode(g.name), ")")
+
+mutable struct BlockMatch <: AbstractSet{AbstractDict{BlockVar, Any}}
+    matches::Set{Dict{BlockVar, Any}}
+end
+
+BlockMatch(xs::Union{Pair, Dict}...) = BlockMatch(Set(Dict.(xs)))
+Base.zero(::Type{BlockMatch}) = BlockMatch()
+Base.one(::Type{BlockMatch}) = BlockMatch(Dict())
+Base.length(Θ::BlockMatch) = length(Θ.matches)
+Base.iterate(Θ::BlockMatch) = iterate(Θ.matches)
+Base.iterate(Θ::BlockMatch, state) = iterate(Θ.matches, state)
+Base.push!(Θ::BlockMatch, items...) = (push!(Θ.matches, items...); Θ)
+Base.copy(Θ::BlockMatch) = BlockMatch(copy(Θ.matches))
+Base.union(Θ₁::BlockMatch, Θ₂::BlockMatch) = BlockMatch(union(Θ₁.matches, Θ₂.matches))
+
+function Base.merge!(Θ::BlockMatch, Θs::BlockMatch...)
+    for Θ′ ∈ Θs
+        result = BlockMatch()
+        for σ′ ∈ Θ′
+            foreach(Θ) do σ
+                res = copy(σ)
+                for (k, v) in σ′
+                    if haskey(σ, k)
+                        σ[k] == v || return
+                    end
+                    res[k] = v
+                end
+                push!(result, res)
+            end
+        end
+        Θ.matches = result
+    end
+    Θ
+end
+
+Base.merge(σ::BlockMatch, σs::BlockMatch...) = merge!(one(BlockMatch), σ, σs...)
+
+function Base.show(io::IO, m::BlockMatch)
+    if isempty(m)
+        print(io, "BlockMatch()")
+    else
+        summary(io, m)
+        println(io)
+        for (match_k, each_d) in enumerate(m)
+            printstyled(io, "Match ", match_k, bold=true)
+            println(io)
+            count = 0
+            for (k, v) in each_d
+                count += 1
+                print(io, k)
+                printstyled(io, " matches", bold=true, color=:green)
+                println(io)
+                print(io, v)
+
+                if count != length(each_d)
+                    println(io)
+                end
+            end
+        end
+    end
+end
+
+# since QBIR is defined as an ADT
+# we only need to deal with runtime pattern ourselves
+# instead handle all the patterns here like what we do in Simplify
+# multiple dispatch will handle all the static inferable pattern
+
+"""
+    match(pattern::AbstractBlock, t::AbstractBlock[, m::BlockMatch])
+
+match a quantum circuit `t` to `pattern`, returns a `BlockMatch`, if the
+user feed in a `BlockMatch`, it will merge the match with the new match.
+
+# Example
+
+You can match a pattern of quantum circuit by using [`BlockVar`](@ref).
+
+```jldoctest
+julia> p = chain(1, var(:x), chain(var(:x), var(:y)))
+nqubits: 1
+chain
+├─ var(1, :x)
+└─ chain
+   ├─ var(1, :x)
+   └─ var(1, :y)
+
+
+julia> match(p, chain(X, chain(X, Y)))
+BlockMatch
+Match 1
+var(1, :x) matches
+X gate
+var(1, :y) matches
+Y gate
+```
+
+Associativity will be handle automatically.
+
+```jldoctest
+julia> p = chain(1, var(:x), chain(var(:y), var(:z)))
+nqubits: 1
+chain
+├─ var(1, :x)
+└─ chain
+   ├─ var(1, :y)
+   └─ var(1, :z)
+
+
+julia> match(p, chain(X, Y, chain(Y, Z)))
+BlockMatch
+Match 1
+var(1, :x) matches
+nqubits: 1
+chain
+├─ X gate
+└─ Y gate
+var(1, :y) matches
+Y gate
+var(1, :z) matches
+Z gate
+```
+"""
+match(pattern::AbstractBlock, term::AbstractBlock) = match(pattern, term, one(BlockMatch))
+# not match by default, so at least it won't be wrong
+match(pattern::AbstractBlock, term::AbstractBlock, θ) = zero(BlockMatch)
+
+# all the patterns and term has the same N below
+# no need to check
+function match(pattern::BlockVar{N}, term::AbstractBlock{N}, θ) where N
+    return _var_match(pattern, term, θ)
+end
+
+function match(pattern::BlockVar{N}, term::PrimitiveBlock{N}, θ) where N
+    return _var_match(pattern, term, θ)
+end
+
+function match(pattern::BlockVar{N}, term::CompositeBlock{N}, θ) where N
+    return _var_match(pattern, term, θ)
+end
+
+
+_var_match(p::BlockVar, t::AbstractBlock, θ) = merge(θ, BlockMatch(p => t))
+
+# chain is only associative
+# it is equivalent to inline the subroutine
+function match(pattern::ChainBlock{N}, term::ChainBlock{N}, θ) where N
+    ac_match(pattern, term, θ)
+end
+
+# primitive block won't match composite block
+function match(pattern::PrimitiveBlock{N}, term::CompositeBlock{N}, θ) where N
+    return zero(BlockMatch)
+end
+
+# constant term will just return previous match
+function match(pattern::B, term::B, θ) where {N, B <: PrimitiveBlock{N}}
+    return θ
+end
+
+# in general, composite block won't match primitive
+# but if it is associative with only one subnode, then
+# it can match, e.g chain/kron
+function match(pattern::CompositeBlock{N}, term::PrimitiveBlock{N}, θ) where N
+    return zero(BlockMatch)
+end
+
+# fallback to pure match
+function match(pattern::CompositeBlock{N}, term::CompositeBlock{N}, θ) where N
+    pure_match(pattern, term, θ)
+end
+
+# we need to compare the positions for some vertical nodes
+function match(pattern::AbstractContainer{<:Any, N}, term::AbstractContainer{<:Any, N}, θ) where N
+    occupied_locs(pattern) == occupied_locs(term) || return zero(BlockMatch)
+    return match(content(pattern), content(term), θ)
+end
+
+"""
+    pure_match(pattern::CompositeBlock{N}, term::CompositeBlock{N}, θ::BlockMatch) where N
+
+match `pattern` to `term` without making assumption on `pattern`'s properties such as associative,
+communitive and anti-communitive. note this will still match its subblocks' properties.
+"""
+function pure_match(pattern::CompositeBlock{N}, term::CompositeBlock{N}, θ::BlockMatch) where N
+    occupied_locs(pattern) == occupied_locs(term) || return zero(BlockMatch)
+    for (x, y) in zip(subblocks(pattern), subblocks(term))
+        θ = match(x, y, θ)
+    end
+    return θ
+end
+
+"""
+    associative_match(pattern::AbstractBlock{N}, term::AbstractBlock{N}, θ::BlockMatch) where N
+
+BlockMatch an associative node to another associative node, such as [`chain`](@ref), [`kron`](@ref),
+Modified based on the implementation in [Simplify.jl](https://github.com/HarrisonGrodin/Simplify.jl/blob/master/src/match.jl),
+based on the algorithm by [Krebber](https://arxiv.org/abs/1705.00907).
+"""
+function associative_match(p::AbstractBlock{N}, s::AbstractBlock{N}, θ::BlockMatch) where N
+    pargs, sargs = subblocks(p), subblocks(s)
+    m, n = length(pargs), length(sargs)
+    m > n && return zero(BlockMatch)
+    n_free = n - m
+    n_vars = count(isvar, pargs)
+    m_r = zero(BlockMatch)
+
+    for k in Iterators.product((0:n_free for i in 1:n_vars)...)
+        (isempty(k) ? 0 : sum(k)) == n_free || continue
+        i, j = 1, 1
+        m = θ
+        for px in pargs
+            l_sub = 0
+            if isvar(px)
+                l_sub += k[j]
+                j += 1
+            end
+            new_s = l_sub > 0 ? chsubblocks(s, sargs[i:i+l_sub]) : sargs[i]
+            m = match(px, new_s, m)
+            isempty(m) && break
+            i += l_sub + 1
+        end
+        m_r = union(m_r, m)
+    end
+    return m_r
+end
+
+# TODO: optimize performance
+# I use some existing tools, but the performance might not be optimal
+using Combinatorics: permutations
+
+function ac_match(p::ChainBlock{N}, s::ChainBlock{N}, θ::BlockMatch) where N
+    intervals = find_communitive_interval(s)
+    isempty(intervals) && return pure_match(p, s, θ)
+
+    it = Iterators.product(map(perms, find_communitive_interval(s))...)
+    matches = map(it) do pms
+        s′ = chain(N)
+        for each in pms
+            for k in each
+                push!(s′, s[k])
+            end
+        end
+        return associative_match(p, s′, θ)
+    end
+
+    return reduce(union, matches)
+end
+
+perms(x::UnitRange) = permutations(x)
+perms(x::Int) = x
+
+function find_communitive_interval(s::ChainBlock)
+    L = length(s)
+    head = 1
+    tail = head
+    intervals = Union{UnitRange{Int}, Int}[]
+    while head <= L
+        if tail < L && iscommute(s[tail], s[tail+1])
+            tail += 1
+        else
+            if tail > head
+                push!(intervals, head:tail)
+            else
+                push!(intervals, head)
+            end
+            head = tail + 1
+            tail = head
+        end
+    end
+    return intervals
+end

--- a/src/treeutils/treeutils.jl
+++ b/src/treeutils/treeutils.jl
@@ -1,4 +1,5 @@
 include("address_manipulate.jl")
 include("optimise.jl")
+include("match.jl")
 
 print_blocktree() = print_subtypetree(AbstractBlock)

--- a/test/match.jl
+++ b/test/match.jl
@@ -1,0 +1,44 @@
+using Test
+using YaoBlocks
+
+@testset "generic match" begin
+    @testset "primitive patterns" begin
+        @test isempty(match(X, Y))
+        @test isempty(match(X, chain(X, Y)))
+
+        @testset "block var" begin
+            x = var(1)
+            @test match(x, chain(X, Y)) == BlockMatch(x => chain(X, Y))
+            @test match(x, X) == BlockMatch(x => X)
+            @test match(x, kron(X, Y)) == BlockMatch()
+
+            y = var(2)
+            @test match(y, kron(X, Y)) == BlockMatch(y => kron(X, Y))
+        end
+    end
+
+    p = kron(var(1, :x), var(1, :x), var(1, :x))
+    @test match(p, kron(X, X, X)) == BlockMatch(var(1, :x) => X)
+end
+
+@testset "associative" begin
+    p = chain(1, var, chain(var, var))
+    c = chain(X, Y, chain(Z, X))
+
+    m = match(p, c)
+    @test length(m) == 1
+    m = first(m)
+    @test m[p[1]] == chain(X, Y)
+    @test m[p[2][1]] == Z
+    @test m[p[2][2]] == X
+
+    p = chain(2, var, chain(var, var))
+    c = chain(2, put(1=>X), kron(X, Y))
+    @test isempty(match(p, c))
+end
+
+@testset "communitive" begin
+    p = chain(3, put(2=>var(1, :x)), put(1=>var(1, :y)))
+    c = chain(3, put(1=>X), put(2=>Y))
+    @test match(p, c) == BlockMatch(Dict(var(1, :y) => X, var(1, :x) => Y))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,3 @@ end
 @testset "autodiff" begin
     include("autodiff/autodiff.jl")
 end
-
-@testset "match" begin
-    include("match.jl")
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,3 +49,7 @@ end
 @testset "autodiff" begin
     include("autodiff/autodiff.jl")
 end
+
+@testset "match" begin
+    include("match.jl")
+end

--- a/test/treeutils.jl
+++ b/test/treeutils.jl
@@ -6,6 +6,10 @@ block_A(i, j) = control(i, j=>shift(2π/(1<<(i-j+1))))
 block_B(n, i) = chain(n, i==j ? put(i=>H) : block_A(j, i) for j in i:n)
 qft(n) = chain(block_B(n, i) for i in 1:n)
 
+@testset "match" begin
+    include("match.jl")
+end
+
 @testset "map address" begin
     # chain, put, concentrator
     c2 = map_address(chain(5, concentrate(5, put(2,2=>X), (4,1)), put(5, 3=>X)), AddressInfo(10, [2,1,4,6,3]))


### PR DESCRIPTION
this PR supports (runtime) pattern matching, it can simplify the implementation of quantum circuit manipulation a lot. This implements the most generic pattern matching handles associative and communitive operators in QBIR.

I'll use pattern matching to support better circuit simplification in another PR. 

Note: we can have more quantum specific matching algorithm to make this more efficient, such as https://arxiv.org/pdf/1909.05270.pdf