### PR TITLE
RFC: Add parameters_range function

### DIFF
--- a/src/abstract_block.jl
+++ b/src/abstract_block.jl
@@ -3,7 +3,7 @@ export AbstractBlock
 using YaoBase, YaoArrayRegister, SimpleTraits
 import YaoBase: @interface
 
-export nqubits, isreflexive, isunitary, ishermitian
+export nqubits, isreflexive, isunitary, ishermitian, parameters_range
 
 """
     AbstractBlock
@@ -343,4 +343,33 @@ use the returns of [`parameters`](@ref) as its key.
 function _check_size(r::AbstractRegister, pb::AbstractBlock{N}) where {N}
     N == nactive(r) ||
         throw(QubitMismatchError("register size $(nactive(r)) mismatch with block size $N"))
+end
+
+"""
+    parameters_range(block)
+
+Return the range of real parameters present in `block`.
+
+!!! note
+    It may not be the case that `length(parameters_range(block)) == nparameters(block)`.
+
+# Example
+
+```jldoctest; setup=:(using YaoBlocks)
+julia> parameters_range(RotationGate(X, 0.1))
+1-element Array{Tuple{Float64,Float64},1}:
+ (0.0, 6.283185307179586)
+```
+"""
+function parameters_range(block::AbstractBlock)
+    T = parameters_eltype(block)
+    out = Tuple{T,T}[]
+    parameters_range!(out, block)
+    out
+end
+
+function parameters_range!(out::Vector{Tuple{T,T}}, block::AbstractBlock) where {T}
+    for subblock in subblocks(block)
+        parameters_range!(out, subblock)
+    end
 end

--- a/src/primitive/phase_gate.jl
+++ b/src/primitive/phase_gate.jl
@@ -52,3 +52,7 @@ Base.copy(block::PhaseGate{T}) where {T} = PhaseGate{T}(block.theta)
 Base.:(==)(lhs::PhaseGate, rhs::PhaseGate) = lhs.theta == rhs.theta
 
 cache_key(gate::PhaseGate) = gate.theta
+
+function parameters_range!(out::Vector{Tuple{T,T}}, gate::PhaseGate{T}) where {T}
+    push!(out, (0.0, 2.0*pi))
+end

--- a/src/primitive/rotation_gate.jl
+++ b/src/primitive/rotation_gate.jl
@@ -125,3 +125,7 @@ Base.:(==)(lhs::RotationGate{TA,GT}, rhs::RotationGate{TB,GT}) where {TA,TB,GT} 
     lhs.theta == rhs.theta
 
 cache_key(R::RotationGate) = R.theta
+
+function parameters_range!(out::Vector{Tuple{T,T}}, gate::RotationGate{N,T,GT}) where {N,T,GT}
+    push!(out, (0.0, 2.0*pi))
+end

--- a/src/primitive/shift_gate.jl
+++ b/src/primitive/shift_gate.jl
@@ -57,3 +57,7 @@ function YaoBase.isunitary(r::ShiftGate)
     @warn "θ in ShiftGate is not real, got θ=$(r.theta), fallback to matrix-based method"
     return isunitary(mat(r))
 end
+
+function parameters_range!(out::Vector{Tuple{T,T}}, gate::ShiftGate{T}) where {T}
+    push!(out, (0.0, 2.0*pi))
+end


### PR DESCRIPTION
New function to return the range of real parameters in a block. No rigorous tests written, but basic cases tested and work as expected in the REPL. Should parameters_range be exported from abstract_block.jl? I noticed that similar function are not. Relatively new to this. Open for comments.