### PR TITLE
fix measure operators

### DIFF
--- a/src/measure_ops.jl
+++ b/src/measure_ops.jl
@@ -116,6 +116,10 @@ function measure!(
     return res
 end
 
+# `BlockedBasis` is for measuring operators on its eigen basis, where a `block` is a subspace with the same eigenvalue.
+# * `perm` is the permutation that permute the basis by the ascending order of eigenvalues,
+# * `values` are eigenvalues of target observable for each block,
+# * `block_ptr` is the pointers for blocks, e.g. to index block `i`, one can use `block_ptr[i]:block_ptr[i-1]`, or `subblock(blockbasis, i)` for short.
 struct BlockedBasis{VT}
     perm::Vector{Int}
     values::VT

--- a/src/measure_ops.jl
+++ b/src/measure_ops.jl
@@ -168,13 +168,13 @@ function YaoBase.measure!(
         end
     end
     res = Vector{Int}(undef, B)
-    @inbounds for ib = 1:B
-        ires = sample(rng, 1:nblocks(bb), Weights(view(pl_block,:,ib)))
+    @inbounds @views for ib = 1:B
+        ires = sample(rng, 1:nblocks(bb), Weights(pl_block[:,ib]))
         # notice ires is `BitStr` type, can be use as indices directly.
         range = subblock(bb,ires)
-        view(state,range,:,ib) ./= sqrt(pl_block[ires, ib])
-        view(state,1:range.start-1,:,ib) .= zero(T)
-        view(state,range.stop+1:size(state,1),:,ib) .= zero(T)
+        state[range,:,ib] ./= sqrt(pl_block[ires, ib])
+        state[1:range.start-1,:,ib] .= zero(T)
+        state[range.stop+1:size(state,1),:,ib] .= zero(T)
         res[ib] = ires
     end
     # undo permute and assign back

--- a/src/measure_ops.jl
+++ b/src/measure_ops.jl
@@ -103,7 +103,7 @@ function eigenbasis(op::YGate)
 end
 
 function measure!(
-    postprocess::PostProcess,
+    postprocess::NoPostProcess,  # operator measuring does not allow removing bits or resetting vaules.
     op::AbstractBlock,
     reg::AbstractRegister,
     locs::AllLocs;
@@ -111,10 +111,81 @@ function measure!(
 )
     _check_msize(op, reg, locs)
     E, V = eigenbasis(op)
-    res = measure!(postprocess, ComputationalBasis(), reg |> V', locs; kwargs...)
-    res2 = measure!(postprocess, ComputationalBasis(), reg, locs; kwargs...)
-    postprocess isa NoPostProcess && apply!(reg, V)
-    diag(mat(E))[Int64.(res).+1]
+    res = measure!(postprocess, BlockedBasis(diag(mat(E))), reg |> V', locs; kwargs...)
+    apply!(reg, V)
+    return res
+end
+
+struct BlockedBasis{VT}
+    perm::Vector{Int}
+    values::VT
+    block_ptr::Vector{Int}
+end
+
+subblock(bb::BlockedBasis, i::Int) = bb.block_ptr[i]:bb.block_ptr[i+1]-1
+nblocks(bb::BlockedBasis) = length(bb.block_ptr)-1
+
+function BlockedBasis(values::AbstractVector{T}) where T
+    if length(values) == 1
+        return BlockedBasis([1], values, [1,2])
+    elseif length(values) == 0
+        return BlockedBasis([], values, [1])
+    end
+    order = sortperm(values; by=real)
+    values = values[order]
+    vpre = values[1]
+    block_ptr = [1]
+    unique_values = [vpre]
+    k = 1
+    for i=2:length(values)
+        v = values[i]
+        if !isapprox(v, vpre)  # use approx in order to ignore the round off error
+            k+=1
+            push!(block_ptr, i)
+            push!(unique_values, v)
+        end
+        vpre = v
+    end
+    push!(block_ptr, length(values)+1)
+    return BlockedBasis(order, unique_values, block_ptr)
+end
+
+function YaoBase.measure!(
+    ::NoPostProcess,
+    bb::BlockedBasis,
+    reg::ArrayReg{B,T},
+    ::AllLocs;
+    rng::AbstractRNG = Random.GLOBAL_RNG,
+) where {B,T}
+    state = (reg |> rank3)[bb.perm,:,:]  # permute to make eigen values sorted
+    pl = dropdims(sum(abs2, state, dims = 2), dims = 2)
+    pl_block = zeros(eltype(pl),nblocks(bb),B)
+    for ib=1:B
+        for i=1:nblocks(bb)
+            for k in subblock(bb, i)
+                pl_block[i,ib] += pl[k,ib]
+            end
+        end
+    end
+    res = Vector{Int}(undef, B)
+    @inbounds for ib = 1:B
+        ires = sample(rng, 1:nblocks(bb), Weights(view(pl_block,:,ib)))
+        # notice ires is `BitStr` type, can be use as indices directly.
+        range = subblock(bb,ires)
+        view(state,range,:,ib) ./= sqrt(pl_block[ires, ib])
+        view(state,1:range.start-1,:,ib) .= zero(T)
+        view(state,range.stop+1:size(state,1),:,ib) .= zero(T)
+        res[ib] = ires
+    end
+    # undo permute and assign back
+    _state = reshape(state, 1<<nactive(reg), :)
+    rstate = reshape(reg.state, 1<<nactive(reg), :)
+    for j = 1:size(rstate,2)
+        for i=1:size(rstate,1)
+            rstate[bb.perm[i],j] = _state[i,j]
+        end
+    end
+    return B == 1 ? bb.values[res[]] : bb.values[res]
 end
 
 function measure(op::AbstractBlock, reg::AbstractRegister, locs::AllLocs; kwargs...)

--- a/test/primitive/measure.jl
+++ b/test/primitive/measure.jl
@@ -55,21 +55,7 @@ end
     @test size(res) == (10,)
     @test res2 == res
 
-    # measure_resetto!
-    reg2 = reg |> copy
-    res = measure!(ResetTo(0), op, reg2, 2:4)
-    reg2 |> repeat(6, H, 2:4)
-    res2 = measure!(ResetTo(0), op, reg2, 2:4)
-    @test size(res) == (10,) == size(res2)
-    @test all(res2 .== 1)
-
-    # measure_remove!
-    reg2 = reg |> copy
-    res = measure!(RemoveMeasured(), op, reg2, 2:4)
-    reg2 |> repeat(3, H, 2:3)
-    @test size(res) == (10,)
-    @test nqubits(reg2) == 3
-
+    # measure_resetto! and measure_remove! for operators are no-longer supported due to its ill property.
     reg = repeat(ArrayReg(ComplexF64[1, -1] / sqrt(2.0)), 10)
     @test measure!(X, reg) |> mean ≈ -1
     reg = repeat(ArrayReg(ComplexF64[1.0, 0]), 1000)
@@ -93,19 +79,6 @@ end
     @test size(res) == (100, 32)
     @test reg ≈ reg2
 
-    # measure_resetto!
-    reg2 = reg |> copy
-    res = measure!(ResetTo(0), op, reg2, 2:6)
-    reg2 |> repeat(8, H, 2:6)
-    res2 = measure!(ResetTo(0), op, reg2, 2:6)
-    @test size(res) == (32,) == size(res2)
-    @test all(res2 .== 1)
-
-    # measure_remove!
-    reg2 = reg |> copy
-    res = measure!(RemoveMeasured(), op, reg2, 2:6)
-    @test size(res) == (32,)
-
     reg = repeat(ArrayReg([1, -1 + 0im] / sqrt(2.0)), 10)
     @test measure!(X, reg) |> mean ≈ -1
     reg = repeat(ArrayReg([1.0, 0 + 0im]), 1000)
@@ -113,4 +86,31 @@ end
 
     m = Measure(5)
     @test chmeasureoperator(m, X) == Measure(5, operator = X)
+end
+
+@testset "measure an operator correctly" begin
+    op = kron(Z,Z)
+    reg = ArrayReg(ComplexF64[1/sqrt(2),0,0,1/sqrt(2)])
+    res = measure!(op, reg)
+    @test res == 1
+    @test reg ≈ ArrayReg(ComplexF64[1/sqrt(2),0,0,1/sqrt(2)])
+    reg = uniform_state(2)
+    res = measure!(op, reg)
+    @test count(!iszero, reg.state) == 2
+
+    # batched
+    reg = ArrayReg(reshape(ComplexF64[1/sqrt(2), 0, 0, 1/sqrt(2), 0.5, 0.5, 0.5, 0.5], 4, 2))
+    res = measure!(op, reg)
+    @test length(reg) == 2 && res[1] == 1
+    @test reg.state[:,1] ≈ ComplexF64[1/sqrt(2),0,0,1/sqrt(2)]
+    @test count(!iszero, reg.state) == 4
+    @test isnormalized(reg)
+
+    # with virtual dimension
+    reg = ArrayReg{1}(reshape(ComplexF64[1/sqrt(2), 0, 0, 1/sqrt(2), 0.5, 0.5, 0.5, 0.5], 4, 2)) / sqrt(2)
+    res = measure!(op, reg)
+    @test length(reg) == 1
+    c = count(!iszero, reg.state)
+    @test (c == 4 && res ≈ 1) || (c == 2 && res == -1)
+    @test isnormalized(reg)
 end

--- a/test/primitive/measure.jl
+++ b/test/primitive/measure.jl
@@ -113,4 +113,10 @@ end
     c = count(!iszero, reg.state)
     @test (c == 4 && res ≈ 1) || (c == 2 && res == -1)
     @test isnormalized(reg)
+
+    # measure zero space
+    reg = ArrayReg(ComplexF64[1.0])
+    res = measure!(matblock(fill(3.0+0im, 1, 1)), reg)
+    @test res ≈ 3.0
+    @test reg == zero_state(0)
 end


### PR DESCRIPTION
The previous measurement of operators is not correct. The correct way to do the measurement should take the degeneracy of eigenvalues seriously, otherwise it might break some good quantum numbers.

New strategy is:
1. project to eigenbasis,
2. sort the eigenvalues,
3. group eigenvalues by their values and compute their group probability,
4. sample by group probability and get group id.
5. project the register to that group.

In the previous naive implementation, you will find the result is correct, but state is project to a different state because we didn't group the eigenvalues. As a result, one can not reproduce certain error correction codes.