### PR TITLE
Port chainrules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.11.6"
 [deps]
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
 CacheServers = "a921213e-d44a-5460-ac04-5d720a99ba71"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LegibleLambdas = "f1f30506-32fe-5131-bd72-7c197988f9e5"
@@ -22,6 +23,7 @@ YaoBase = "a8f54c17-34bc-5a9d-b050-f522fe3f755f"
 
 [compat]
 BitBasis = "0.7"
+ChainRulesCore = "1.11"
 CacheServers = "0.2"
 ExponentialUtilities = "1.5"
 LegibleLambdas = "0.2, 0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -23,8 +23,8 @@ YaoBase = "a8f54c17-34bc-5a9d-b050-f522fe3f755f"
 
 [compat]
 BitBasis = "0.7"
-ChainRulesCore = "1.11"
 CacheServers = "0.2"
+ChainRulesCore = "1.11"
 ExponentialUtilities = "1.5"
 LegibleLambdas = "0.2, 0.3"
 LuxurySparse = "0.6"
@@ -39,6 +39,8 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test"]
+test = ["Test", "ForwardDiff", "Zygote"]

--- a/src/autodiff/autodiff.jl
+++ b/src/autodiff/autodiff.jl
@@ -24,5 +24,6 @@ include("mat_back.jl")
 include("apply_back.jl")
 include("specializes.jl")
 include("gradcheck.jl")
+include("chainrules_patch.jl")
 
 end

--- a/src/autodiff/chainrules_patch.jl
+++ b/src/autodiff/chainrules_patch.jl
@@ -1,0 +1,61 @@
+import ChainRulesCore: rrule, @non_differentiable, NoTangent
+
+function rrule(::typeof(apply), reg::ArrayReg, block::AbstractBlock)
+    out = apply(reg, block)
+    out, function (outδ)
+        (in, inδ), paramsδ = apply_back((copy(out), outδ), block)
+        return (NoTangent(), inδ, paramsδ)
+    end
+end
+
+function rrule(::typeof(dispatch), block::AbstractBlock, params)
+    out = dispatch(block, params)
+    out, function (outδ)
+        (NoTangent(), NoTangent(), outδ)
+    end
+end
+
+function rrule(::typeof(expect), op::AbstractBlock, reg::AbstractRegister{B}) where {B}
+    out = expect(op, reg)
+    out, function (outδ)
+        greg = expect_g(op, reg)
+        for b=1:B
+            viewbatch(greg, b).state .*= 2*outδ[b]
+        end
+        return (NoTangent(), NoTangent(), greg)
+    end
+end
+
+function rrule(::Type{Matrix}, block::AbstractBlock)
+    out = Matrix(block)
+    out, function (outδ)
+        paramsδ = mat_back(block, outδ)
+        return (NoTangent(), paramsδ)
+    end
+end
+
+function rrule(::Type{ArrayReg{B}}, raw::AbstractArray) where B
+    ArrayReg{B}(raw), adjy->(NoTangent(), reshape(adjy.state, size(raw)))
+end
+
+function rrule(::Type{ArrayReg}, raw::AbstractArray)
+    ArrayReg(raw), adjy->(NoTangent(), reshape(adjy.state, size(raw)))
+end
+
+function rrule(::typeof(copy), reg::ArrayReg) where B
+    copy(reg), adjy->(NoTangent(), adjy)
+end
+
+_totype(::Type{T}, x::AbstractArray{T}) where T = x
+_totype(::Type{T}, x::AbstractArray{T2}) where {T,T2} = convert.(T, x)
+rrule(::typeof(state), reg::ArrayReg{B,T}) where {B,T} = state(reg), adjy->(NoTangent(), ArrayReg(_totype(T, adjy)))
+rrule(::typeof(statevec), reg::ArrayReg{B,T}) where {B,T} = statevec(reg), adjy->(NoTangent(), ArrayReg(_totype(T, adjy)))
+rrule(::typeof(state), reg::AdjointArrayReg{B,T}) where {B,T} = state(reg), adjy->(NoTangent(), ArrayReg(_totype(T, adjy)')')
+rrule(::typeof(statevec), reg::AdjointArrayReg{B,T}) where {B,T} = statevec(reg), adjy->(NoTangent(), ArrayReg(_totype(T, adjy)')')
+rrule(::typeof(parent), reg::AdjointArrayReg) = parent(reg), adjy->(NoTangent(), adjy')
+rrule(::typeof(Base.adjoint), reg::ArrayReg) = Base.adjoint(reg), adjy->(NoTangent(), parent(adjy))
+@non_differentiable nparameters(::Any)
+@non_differentiable zero_state(args...)
+@non_differentiable rand_state(args...)
+@non_differentiable uniform_state(args...)
+@non_differentiable product_state(args...)

--- a/src/measure_ops.jl
+++ b/src/measure_ops.jl
@@ -141,7 +141,7 @@ function BlockedBasis(values::AbstractVector{T}) where {T}
     block_ptr = [1]
     unique_values = [vpre]
     k = 1
-    for i in 2:length(values)
+    @inbounds for i in 2:length(values)
         v = values[i]
         if !isapprox(v, vpre)  # use approx in order to ignore the round off error
             k += 1
@@ -161,10 +161,10 @@ function YaoBase.measure!(
     ::AllLocs;
     rng::AbstractRNG = Random.GLOBAL_RNG,
 ) where {B,T}
-    state = (reg|>rank3)[bb.perm, :, :]  # permute to make eigen values sorted
+    state = @inbounds (reg|>rank3)[bb.perm, :, :]  # permute to make eigen values sorted
     pl = dropdims(sum(abs2, state, dims = 2), dims = 2)
     pl_block = zeros(eltype(pl), nblocks(bb), B)
-    for ib in 1:B
+    @inbounds for ib in 1:B
         for i in 1:nblocks(bb)
             for k in subblock(bb, i)
                 pl_block[i, ib] += pl[k, ib]
@@ -184,7 +184,7 @@ function YaoBase.measure!(
     # undo permute and assign back
     _state = reshape(state, 1 << nactive(reg), :)
     rstate = reshape(reg.state, 1 << nactive(reg), :)
-    for j in 1:size(rstate, 2)
+    @inbounds for j in 1:size(rstate, 2)
         for i in 1:size(rstate, 1)
             rstate[bb.perm[i], j] = _state[i, j]
         end

--- a/test/autodiff/autodiff.jl
+++ b/test/autodiff/autodiff.jl
@@ -24,3 +24,7 @@ end
 @testset "specializes" begin
     include("specializes.jl")
 end
+
+@testset "chainrules_patch" begin
+    include("chainrules_patch.jl")
+end

--- a/test/autodiff/chainrules_patch.jl
+++ b/test/autodiff/chainrules_patch.jl
@@ -16,7 +16,7 @@ using YaoBlocks, YaoArrayRegister
     g1 = reinterpret(ComplexF64, ForwardDiff.gradient(x->real(sum(abs2, [Complex(x[2i-1],x[2i]) for i=1:length(x)÷2])), reinterpret(Float64,r.state)))
     @test Zygote.gradient(x->real(sum(abs2, state(x'))), r)[1].state ≈ g1
     @test Zygote.gradient(x->real(sum(abs2, statevec(x'))), r)[1].state ≈ g1
-    # fucking zygote does not work if `sin` is not here,
+    # zygote does not work if `sin` is not here,
     # because it gives an adjoint of different type as the output matrix type.
     # do not modify the data type please! Zygote
     @test Zygote.gradient(x->real(sum(sin, Matrix(x))), c)[1] ≈ ForwardDiff.gradient(x->real(sum(sin, Matrix(dispatch(c, x)))), parameters(c))

--- a/test/autodiff/chainrules_patch.jl
+++ b/test/autodiff/chainrules_patch.jl
@@ -1,6 +1,6 @@
 import Zygote, ForwardDiff
 using Random, Test
-using Yao
+using YaoBlocks, YaoArrayRegister
 
 @testset "rules" begin
     h = put(5, 3=>Z) + put(5, 2=>X)
@@ -17,7 +17,7 @@ using Yao
     @test Zygote.gradient(x->real(sum(abs2, state(x'))), r)[1].state ≈ g1
     @test Zygote.gradient(x->real(sum(abs2, statevec(x'))), r)[1].state ≈ g1
     # fucking zygote does not work if `sin` is not here,
-    # because it gives an adjoint of different type as output matrix type.
+    # because it gives an adjoint of different type as the output matrix type.
     # do not modify the data type please! Zygote
     @test Zygote.gradient(x->real(sum(sin, Matrix(x))), c)[1] ≈ ForwardDiff.gradient(x->real(sum(sin, Matrix(dispatch(c, x)))), parameters(c))
 end

--- a/test/autodiff/chainrules_patch.jl
+++ b/test/autodiff/chainrules_patch.jl
@@ -1,0 +1,43 @@
+import Zygote, ForwardDiff
+using Random, Test
+using Yao
+
+@testset "rules" begin
+    h = put(5, 3=>Z) + put(5, 2=>X)
+    c = chain(put(5, 2=>chain(Rx(1.4), Rx(0.5))), cnot(5, 3, 1), put(5, 3=>Rx(-0.5)))
+    r = rand_state(5)
+    g0 = reinterpret(ComplexF64, ForwardDiff.gradient(x->real(expect(h, ArrayReg([Complex(x[2i-1],x[2i]) for i=1:length(x)÷2]))), reinterpret(Float64,r.state)))
+    @test Zygote.gradient(x->real(expect(h, ArrayReg(x))), r.state)[1] ≈ g0
+    @test Zygote.gradient(x->real(expect(h, ArrayReg{1}(reshape(statevec(x),:,1)))), r)[1].state ≈ g0
+    @test Zygote.gradient(x->real(expect(h, ArrayReg(reshape(state(x),:,1)))), r)[1].state ≈ g0
+    @test Zygote.gradient(x->real(expect(h, copy(x))), r)[1].state ≈ g0
+    @test Zygote.gradient(x->real(expect(h, parent(x'))), r)[1].state ≈ g0
+
+    g1 = reinterpret(ComplexF64, ForwardDiff.gradient(x->real(sum(abs2, [Complex(x[2i-1],x[2i]) for i=1:length(x)÷2])), reinterpret(Float64,r.state)))
+    @test Zygote.gradient(x->real(sum(abs2, state(x'))), r)[1].state ≈ g1
+    @test Zygote.gradient(x->real(sum(abs2, statevec(x'))), r)[1].state ≈ g1
+    # fucking zygote does not work if `sin` is not here,
+    # because it gives an adjoint of different type as output matrix type.
+    # do not modify the data type please! Zygote
+    @test Zygote.gradient(x->real(sum(sin, Matrix(x))), c)[1] ≈ ForwardDiff.gradient(x->real(sum(sin, Matrix(dispatch(c, x)))), parameters(c))
+end
+
+@testset "adwith zygote" begin
+    c = chain(put(5, 2=>chain(Rx(0.4), Rx(0.5))), cnot(5, 3, 1), put(5, 3=>Rx(-0.5)))
+    dispatch!(c, :random)
+
+    function loss(reg::AbstractRegister, circuit::AbstractBlock{N}) where N
+        reg = apply(copy(reg), circuit)
+        st = state(reg)
+        sum(real(st.*st))
+    end
+
+    reg0 = zero_state(5)
+    params = rand!(parameters(c))
+    paramsδ = Zygote.gradient(params->loss(reg0, dispatch(c, params)), params)[1]
+    regδ = Zygote.gradient(reg->loss(reg, c), reg0)[1]
+    fparamsδ = ForwardDiff.gradient(params->loss(ArrayReg(Matrix{Complex{eltype(params)}}(reg0.state)), dispatch(c, params)), params)
+    fregδ = ForwardDiff.gradient(x->loss(ArrayReg([Complex(x[2i-1],x[2i]) for i=1:length(x)÷2]), dispatch(c, Vector{real(eltype(x))}(parameters(c)))), reinterpret(Float64,reg0.state))
+    @test fregδ ≈ reinterpret(Float64, regδ.state)
+    @test fparamsδ ≈ paramsδ
+end


### PR DESCRIPTION
port AD rules into ChainRules so that it can be used in Zygote directly.

# example

```julia
    c = chain(put(5, 2=>chain(Rx(0.4), Rx(0.5))), cnot(5, 3, 1), put(5, 3=>Rx(-0.5)))
    dispatch!(c, :random)

    function loss(reg::AbstractRegister, circuit::AbstractBlock{N}) where N
        reg = apply(copy(reg), circuit)
        st = state(reg)
        sum(real(st.*st))
    end

    reg0 = zero_state(5)
    params = rand!(parameters(c))
    paramsδ = Zygote.gradient(params->loss(reg0, dispatch(c, params)), params)[1]
    regδ = Zygote.gradient(reg->loss(reg, c), reg0)[1]
    fparamsδ = ForwardDiff.gradient(params->loss(ArrayReg(Matrix{Complex{eltype(params)}}(reg0.state)), dispatch(c, params)), params)
    fregδ = ForwardDiff.gradient(x->loss(ArrayReg([Complex(x[2i-1],x[2i]) for i=1:length(x)÷2]), dispatch(c, Vector{real(eltype(x))}(parameters(c)))), reinterpret(Float64,reg0.state))
    @test fregδ ≈ reinterpret(Float64, regδ.state)
    @test fparamsδ ≈ paramsδ
```