### PR TITLE
Fix issue 170

### DIFF
--- a/src/autodiff/chainrules_patch.jl
+++ b/src/autodiff/chainrules_patch.jl
@@ -1,10 +1,10 @@
-import ChainRulesCore: rrule, @non_differentiable, NoTangent
+import ChainRulesCore: rrule, @non_differentiable, NoTangent, Tangent
 
 function rrule(::typeof(apply), reg::ArrayReg, block::AbstractBlock)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block)
-        return (NoTangent(), inδ, paramsδ)
+        return (NoTangent(), inδ, dispatch(block, paramsδ))
     end
 end
 
@@ -12,14 +12,14 @@ function rrule(::typeof(apply), reg::ArrayReg, block::Add)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block; in = reg)
-        return (NoTangent(), inδ, paramsδ)
+        return (NoTangent(), inδ, dispatch(block, paramsδ))
     end
 end
 
 function rrule(::typeof(dispatch), block::AbstractBlock, params)
     out = dispatch(block, params)
     out, function (outδ)
-        (NoTangent(), NoTangent(), outδ)
+        (NoTangent(), NoTangent(), parameters(outδ))
     end
 end
 
@@ -34,11 +34,34 @@ function rrule(::typeof(expect), op::AbstractBlock, reg::AbstractRegister{B}) wh
     end
 end
 
-function rrule(::Type{Matrix}, block::AbstractBlock)
-    out = Matrix(block)
+function rrule(::typeof(expect), op::AbstractBlock, reg_and_circuit::Pair{<:ArrayReg{B},<:AbstractBlock}) where {B}
+    out = expect(op, reg_and_circuit)
+    out, function (outδ)
+        greg, gcircuit = expect_g(op, reg_and_circuit)
+        for b in 1:B
+            viewbatch(greg, b).state .*= 2 * outδ[b]
+        end
+        return (NoTangent(), NoTangent(), Tangent{typeof(reg_and_circuit)}(; first=greg, second=dispatch(reg_and_circuit.second, gcircuit)))
+    end
+end
+
+#function rrule(::Type{PT}, reg::ArrayReg{B}, circ::AbstractBlock) where {B,PT<:Pair}
+    #Pair(reg, circ), outδ->(NoTangent(), outδ.first, outδ.second)
+#end
+
+function rrule(::Type{T}, block::AbstractBlock) where T<:Matrix
+    out = T(block)
     out, function (outδ)
         paramsδ = mat_back(block, outδ)
-        return (NoTangent(), paramsδ)
+        return (NoTangent(), dispatch(block, paramsδ))
+    end
+end
+
+function rrule(::typeof(mat), ::Type{T}, block::AbstractBlock) where T
+    out = mat(T, block)
+    out, function (outδ)
+        paramsδ = mat_back(block, outδ)
+        return (NoTangent(), NoTangent(), dispatch(block, paramsδ))
     end
 end
 

--- a/src/autodiff/chainrules_patch.jl
+++ b/src/autodiff/chainrules_patch.jl
@@ -45,10 +45,6 @@ function rrule(::typeof(expect), op::AbstractBlock, reg_and_circuit::Pair{<:Arra
     end
 end
 
-#function rrule(::Type{PT}, reg::ArrayReg{B}, circ::AbstractBlock) where {B,PT<:Pair}
-    #Pair(reg, circ), outδ->(NoTangent(), outδ.first, outδ.second)
-#end
-
 function rrule(::Type{T}, block::AbstractBlock) where T<:Matrix
     out = T(block)
     out, function (outδ)


### PR DESCRIPTION
This PR will fix #170 .
The previous gradient of a circuit is a vector of circuit parameter gradients. This causes the problem in #170 .
The gradient of a circuit now is a Yao Block instead of a vector type.

This solution is not yet perfect, the best return type should be `Tagent{<:AbstractBlock}`, because when you want to accumulate gradients, the block arithmetics does not do the right thing. As a result, you still need a patch for Zygote:
```julia
function Zygote.accum(a::AbstractBlock, b::AbstractBlock)
    dispatch(a, parameters(a) + parameters(b))
end
```