### PR TITLE
[WIP] Fix 170 - an improved patch

### DIFF
--- a/src/autodiff/chainrules_patch.jl
+++ b/src/autodiff/chainrules_patch.jl
@@ -1,10 +1,10 @@
-import ChainRulesCore: rrule, @non_differentiable, NoTangent
+import ChainRulesCore: rrule, @non_differentiable, NoTangent, Tangent
 
 function rrule(::typeof(apply), reg::ArrayReg, block::AbstractBlock)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block)
-        return (NoTangent(), inδ, paramsδ)
+        return (NoTangent(), inδ, dispatch(block, paramsδ))
     end
 end
 
@@ -12,14 +12,14 @@ function rrule(::typeof(apply), reg::ArrayReg, block::Add)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block; in = reg)
-        return (NoTangent(), inδ, paramsδ)
+        return (NoTangent(), inδ, dispatch(block, paramsδ))
     end
 end
 
 function rrule(::typeof(dispatch), block::AbstractBlock, params)
     out = dispatch(block, params)
     out, function (outδ)
-        (NoTangent(), NoTangent(), outδ)
+        (NoTangent(), NoTangent(), parameters(outδ))
     end
 end
 
@@ -34,11 +34,34 @@ function rrule(::typeof(expect), op::AbstractBlock, reg::AbstractRegister{B}) wh
     end
 end
 
-function rrule(::Type{Matrix}, block::AbstractBlock)
-    out = Matrix(block)
+function rrule(::typeof(expect), op::AbstractBlock, reg_and_circuit::Pair{<:ArrayReg{B},<:AbstractBlock}) where {B}
+    out = expect(op, reg_and_circuit)
+    out, function (outδ)
+        greg, gcircuit = expect_g(op, reg_and_circuit)
+        for b in 1:B
+            viewbatch(greg, b).state .*= 2 * outδ[b]
+        end
+        return (NoTangent(), NoTangent(), Tangent{typeof(reg_and_circuit)}(; first=greg, second=dispatch(reg_and_circuit.second, gcircuit)))
+    end
+end
+
+#function rrule(::Type{PT}, reg::ArrayReg{B}, circ::AbstractBlock) where {B,PT<:Pair}
+    #Pair(reg, circ), outδ->(NoTangent(), outδ.first, outδ.second)
+#end
+
+function rrule(::Type{T}, block::AbstractBlock) where T<:Matrix
+    out = T(block)
     out, function (outδ)
         paramsδ = mat_back(block, outδ)
-        return (NoTangent(), paramsδ)
+        return (NoTangent(), dispatch(block, paramsδ))
+    end
+end
+
+function rrule(::typeof(mat), ::Type{T}, block::AbstractBlock) where T
+    out = mat(T, block)
+    out, function (outδ)
+        paramsδ = mat_back(block, outδ)
+        return (NoTangent(), NoTangent(), dispatch(block, paramsδ))
     end
 end
 

--- a/src/autodiff/chainrules_patch.jl
+++ b/src/autodiff/chainrules_patch.jl
@@ -45,10 +45,6 @@ function rrule(::typeof(expect), op::AbstractBlock, reg_and_circuit::Pair{<:Arra
     end
 end
 
-#function rrule(::Type{PT}, reg::ArrayReg{B}, circ::AbstractBlock) where {B,PT<:Pair}
-    #Pair(reg, circ), outδ->(NoTangent(), outδ.first, outδ.second)
-#end
-
 function rrule(::Type{T}, block::AbstractBlock) where T<:Matrix
     out = T(block)
     out, function (outδ)

--- a/src/autodiff/chainrules_patch.jl
+++ b/src/autodiff/chainrules_patch.jl
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import ChainRulesCore: rrule, @non_differentiable, NoTangent, Tangent, backing, AbstractTangent, ZeroTangent
 
 function create_circuit_tangent(circuit, params)
@@ -56,47 +55,31 @@ function extract_circuit_gradients!(c::Tangent, output)
     end
     return output
 end
-=======
-import ChainRulesCore: rrule, @non_differentiable, NoTangent, Tangent
->>>>>>> master
 
 function rrule(::typeof(apply), reg::ArrayReg, block::AbstractBlock)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block)
-<<<<<<< HEAD
         return (NoTangent(), inδ, create_circuit_tangent(block, paramsδ))
-=======
-        return (NoTangent(), inδ, dispatch(block, paramsδ))
->>>>>>> master
     end
 end
 function rrule(::typeof(apply), reg::ArrayReg, block::Add)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block; in = reg)
-<<<<<<< HEAD
         return (NoTangent(), inδ, create_circuit_tangent(block, paramsδ))
-=======
-        return (NoTangent(), inδ, dispatch(block, paramsδ))
->>>>>>> master
     end
 end
 
 
 function rrule(::typeof(dispatch), block::AbstractBlock, params)
     out = dispatch(block, params)
-<<<<<<< HEAD
     out, function (outδ::AbstractTangent)
         #δ= getfield(outδ,:backing)
         #g = extract_circuit_gradients!(Tangent{typeof(block),typeof(δ)}(δ), empty(params))
         g = extract_circuit_gradients!(outδ, empty(params))
         res = (NoTangent(), NoTangent(), g)
         return res
-=======
-    out, function (outδ)
-        (NoTangent(), NoTangent(), parameters(outδ))
->>>>>>> master
     end
 end
 
@@ -118,11 +101,7 @@ function rrule(::typeof(expect), op::AbstractBlock, reg_and_circuit::Pair{<:Arra
         for b in 1:B
             viewbatch(greg, b).state .*= 2 * outδ[b]
         end
-<<<<<<< HEAD
         return (NoTangent(), NoTangent(), Tangent{typeof(reg_and_circuit)}(; first=greg, second=create_circuit_tangent(reg_and_circuit.second, gcircuit)))
-=======
-        return (NoTangent(), NoTangent(), Tangent{typeof(reg_and_circuit)}(; first=greg, second=dispatch(reg_and_circuit.second, gcircuit)))
->>>>>>> master
     end
 end
 
@@ -130,11 +109,7 @@ function rrule(::Type{T}, block::AbstractBlock) where T<:Matrix
     out = T(block)
     out, function (outδ)
         paramsδ = mat_back(block, outδ)
-<<<<<<< HEAD
         return (NoTangent(), create_circuit_tangent(block, paramsδ))
-=======
-        return (NoTangent(), dispatch(block, paramsδ))
->>>>>>> master
     end
 end
 
@@ -142,11 +117,7 @@ function rrule(::typeof(mat), ::Type{T}, block::AbstractBlock) where T
     out = mat(T, block)
     out, function (outδ)
         paramsδ = mat_back(block, outδ)
-<<<<<<< HEAD
         return (NoTangent(), NoTangent(), create_circuit_tangent(block, paramsδ))
-=======
-        return (NoTangent(), NoTangent(), dispatch(block, paramsδ))
->>>>>>> master
     end
 end
 

--- a/src/autodiff/chainrules_patch.jl
+++ b/src/autodiff/chainrules_patch.jl
@@ -1,25 +1,85 @@
-import ChainRulesCore: rrule, @non_differentiable, NoTangent, Tangent
+import ChainRulesCore: rrule, @non_differentiable, NoTangent, Tangent, backing, AbstractTangent, ZeroTangent
+
+function create_circuit_tangent(circuit, params)
+    gc = dispatch(circuit, params)
+    res = recursive_create_tangent(gc)
+    return res
+end
+
+# fallback
+function recursive_create_tangent(c::AbstractBlock)
+    if nparameters(c) == 0
+        return NoTangent()
+    else
+        error("`Tangent` for type $(typeof(c)) is not defined!")
+    end
+end
+# primitive blocks
+unsafe_primitive_tangent(::Any) = NoTangent()
+unsafe_primitive_tangent(x::Number) = x
+for GT in [:RotationGate, :ShiftGate, :TimeEvolution, :PhaseGate]
+    @eval function recursive_create_tangent(c::$GT)
+        lst = map(fieldnames(typeof(c))) do fn
+            fn => unsafe_primitive_tangent(getfield(c, fn))
+        end
+        nt = NamedTuple(lst)
+        Tangent{typeof(c), typeof(nt)}(nt)
+    end
+end
+# composite blocks
+unsafe_composite_tangent(::Any) = NoTangent()
+unsafe_composite_tangent(c::AbstractVector{<:AbstractBlock}) = recursive_create_tangent.(c)
+unsafe_composite_tangent(c::AbstractBlock) = recursive_create_tangent(c)
+for GT in [:ChainBlock, :Add, :KronBlock, :RepeatedBlock, :PutBlock, :Subroutine, :CachedBlock, :Daggered, :Scale]
+    @eval function recursive_create_tangent(c::$GT)
+        lst = map(fieldnames(typeof(c))) do fn
+            fn => unsafe_composite_tangent(getfield(c, fn))
+        end
+        nt = NamedTuple(lst)
+        Tangent{typeof(c), typeof(nt)}(nt)
+    end
+end
+
+extract_circuit_gradients!(c::Number, output) = push!(output, c)
+extract_circuit_gradients!(::NoTangent, output) = output
+extract_circuit_gradients!(::ZeroTangent, output) = output
+function extract_circuit_gradients!(c::AbstractVector, output)
+    for ci in c
+        extract_circuit_gradients!(ci, output)
+    end
+    return output
+end
+function extract_circuit_gradients!(c::Tangent, output)
+    for fn in getfield(c, :backing)
+        extract_circuit_gradients!(fn, output)
+    end
+    return output
+end
 
 function rrule(::typeof(apply), reg::ArrayReg, block::AbstractBlock)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block)
-        return (NoTangent(), inδ, dispatch(block, paramsδ))
+        return (NoTangent(), inδ, create_circuit_tangent(block, paramsδ))
     end
 end
-
 function rrule(::typeof(apply), reg::ArrayReg, block::Add)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block; in = reg)
-        return (NoTangent(), inδ, dispatch(block, paramsδ))
+        return (NoTangent(), inδ, create_circuit_tangent(block, paramsδ))
     end
 end
 
+
 function rrule(::typeof(dispatch), block::AbstractBlock, params)
     out = dispatch(block, params)
-    out, function (outδ)
-        (NoTangent(), NoTangent(), parameters(outδ))
+    out, function (outδ::AbstractTangent)
+        #δ= getfield(outδ,:backing)
+        #g = extract_circuit_gradients!(Tangent{typeof(block),typeof(δ)}(δ), empty(params))
+        g = extract_circuit_gradients!(outδ, empty(params))
+        res = (NoTangent(), NoTangent(), g)
+        return res
     end
 end
 
@@ -41,7 +101,7 @@ function rrule(::typeof(expect), op::AbstractBlock, reg_and_circuit::Pair{<:Arra
         for b in 1:B
             viewbatch(greg, b).state .*= 2 * outδ[b]
         end
-        return (NoTangent(), NoTangent(), Tangent{typeof(reg_and_circuit)}(; first=greg, second=dispatch(reg_and_circuit.second, gcircuit)))
+        return (NoTangent(), NoTangent(), Tangent{typeof(reg_and_circuit)}(; first=greg, second=create_circuit_tangent(reg_and_circuit.second, gcircuit)))
     end
 end
 
@@ -49,7 +109,7 @@ function rrule(::Type{T}, block::AbstractBlock) where T<:Matrix
     out = T(block)
     out, function (outδ)
         paramsδ = mat_back(block, outδ)
-        return (NoTangent(), dispatch(block, paramsδ))
+        return (NoTangent(), create_circuit_tangent(block, paramsδ))
     end
 end
 
@@ -57,7 +117,7 @@ function rrule(::typeof(mat), ::Type{T}, block::AbstractBlock) where T
     out = mat(T, block)
     out, function (outδ)
         paramsδ = mat_back(block, outδ)
-        return (NoTangent(), NoTangent(), dispatch(block, paramsδ))
+        return (NoTangent(), NoTangent(), create_circuit_tangent(block, paramsδ))
     end
 end
 
@@ -71,6 +131,23 @@ end
 
 function rrule(::typeof(copy), reg::ArrayReg) where {B}
     copy(reg), adjy -> (NoTangent(), adjy)
+end
+
+for (BT, BLOCKS) in [(:Add, :(outδ.list)) (:ChainBlock, :(outδ.blocks))]
+    for ST in [:AbstractVector, :Tuple]
+        @eval function rrule(::Type{BT}, source::$ST) where {N, BT<:$BT}
+            out = BT(source)
+            out, function (outδ)
+                return (NoTangent(), $ST($BLOCKS))
+            end
+        end
+    end
+    @eval function rrule(::Type{BT}, args::AbstractBlock...) where {N, BT <: $BT}
+        out = BT(args...)
+        out, function (outδ)
+            return (NoTangent(), $BLOCKS...)
+        end
+    end
 end
 
 _totype(::Type{T}, x::AbstractArray{T}) where {T} = x


### PR DESCRIPTION
This is fix the issue in comment: https://github.com/QuantumBFS/YaoBlocks.jl/issues/170#issuecomment-969119037

But there are still some bugs related to Zygote.

e.g. 
```julia
julia> Zygote.gradient(x->x.content.theta, Daggered(Rx(0.5)))
(nothing,)
```

I do not know why this gradient is so hard for Zygote. @Roger-luo 