### PR TITLE
redesign mat interface for const gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _*.yao
 docs/build/
 docs/site/
 Manifest.toml
+*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "YaoBlocks"
 uuid = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
-version = "0.11.9"
+version = "0.11.10"
 
 [deps]
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"

--- a/src/primitive/const_gate_tools.jl
+++ b/src/primitive/const_gate_tools.jl
@@ -169,13 +169,14 @@ function define_binding(__module__::Module, const_binding, expr)
     end
 end
 
+# forward instance to const gate type
+YaoBlocks.mat(::Type{T}, ::GT) where {T,GT<:ConstantGate} = YaoBlocks.mat(T, GT)
+
 function define_methods(__module__::Module, const_binding, name)
     gt_name = gatetype_name(name)
     return quote
         @eval $__module__ begin
             YaoBlocks.mat(::Type{eltype($const_binding)}, ::Type{$gt_name}) = $const_binding
-            # forward instance to const gate type
-            YaoBlocks.mat(::Type{T}, ::GT) where {T,GT<:$gt_name} = YaoBlocks.mat(T, GT)
 
             function YaoBlocks.mat(::Type{T}, ::Type{$gt_name}) where {T}
                 src = YaoBlocks.mat(eltype($const_binding), $gt_name)


### PR DESCRIPTION
I want to define `mat(Basic, ::ConstantGate)` in a more general style, however, this interface can not be overloaded without ambiguity error. This is the easiest way to solve the problem.